### PR TITLE
Connection modes deploy 2: legacy shim removal + guarded settings cleanup

### DIFF
--- a/convex/account.test.ts
+++ b/convex/account.test.ts
@@ -503,9 +503,10 @@ describe('account.switchBackend guards', () => {
     await t.run(async (ctx) => {
       // The member chose privacy (unbound); only evade has a pool bound.
       await ctx.db.patch(userId, { connectionModeId: 'privacy-reality' });
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.freedom-ws.squads',
-        value: JSON.stringify(['sq-freedom-ws']),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-ws',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['sq-freedom-ws'] }),
         updatedAt: Date.now(),
       });
     });
@@ -560,9 +561,10 @@ describe('account.switchMode saga', () => {
     // freedom-reality ships dark. Binding a pool must not make it selectable —
     // the operator turns it on deliberately, in the admin panel.
     await t.run((ctx) =>
-      ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.freedom-reality.squads',
-        value: JSON.stringify(['11111111-2222-3333-4444-555555555555']),
+      ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-reality',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['11111111-2222-3333-4444-555555555555'] }),
         updatedAt: Date.now(),
       }),
     );
@@ -584,9 +586,10 @@ describe('account.switchMode saga', () => {
     const userId = await seedUser(t, tierId);
     await t.run(async (ctx) => {
       await ctx.db.patch(userId, { connectionModeId: 'freedom-reality' }); // disabled
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.freedom-ws.squads',
-        value: JSON.stringify(['11111111-2222-3333-4444-555555555555']),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-ws',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['11111111-2222-3333-4444-555555555555'] }),
         updatedAt: Date.now(),
       });
     });
@@ -606,9 +609,10 @@ describe('account.switchMode saga', () => {
     const userId = await seedUser(t, tierId);
     await t.run(async (ctx) => {
       // Bind the privacy mode's placement pool — the infra detail never audited.
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.privacy-reality.squads',
-        value: JSON.stringify([SQUAD]),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'privacy-reality',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: [SQUAD] }),
         updatedAt: Date.now(),
       });
       const instanceId = await ctx.db.insert('backendServers', {
@@ -718,9 +722,10 @@ describe('account.switchMode saga', () => {
     const tierId = await seedTier(t, { backend: 'remnawave' });
     const userId = await seedUser(t, tierId);
     const { activeInstanceId } = await t.run(async (ctx) => {
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.privacy-reality.squads',
-        value: JSON.stringify([SQUAD]),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'privacy-reality',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: [SQUAD] }),
         updatedAt: Date.now(),
       });
       // The panel row the sub was issued against was deleted + re-registered
@@ -818,9 +823,10 @@ describe('account.switchMode saga', () => {
     const tierId = await seedTier(t, { backend: 'remnawave' });
     const userId = await seedUser(t, tierId);
     await t.run(async (ctx) => {
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.privacy-reality.squads',
-        value: JSON.stringify([SQUAD]),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'privacy-reality',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: [SQUAD] }),
         updatedAt: Date.now(),
       });
       const instanceId = await ctx.db.insert('backendServers', {
@@ -913,9 +919,10 @@ describe('account.switchMode saga', () => {
     const tierId = await seedTier(t, { backend: 'remnawave' });
     const userId = await seedUser(t, tierId);
     await t.run(async (ctx) => {
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.privacy-reality.squads',
-        value: JSON.stringify([SQUAD]),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'privacy-reality',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: [SQUAD] }),
         updatedAt: Date.now(),
       });
       await ctx.db.insert('backendServers', {
@@ -978,9 +985,10 @@ describe('account.switchMode saga', () => {
     const userId = await seedUser(t, tierId);
     await t.run(async (ctx) => {
       // evade is bound; privacy is NOT — switching to privacy must be refused.
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.freedom-ws.squads',
-        value: JSON.stringify(['sq-freedom-ws']),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-ws',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['sq-freedom-ws'] }),
         updatedAt: Date.now(),
       });
       const subId = await ctx.db.insert('subscriptions', {
@@ -1026,9 +1034,10 @@ describe('account.switchMode saga', () => {
     await t.run(async (ctx) => {
       // The member chose privacy (unbound); only evade has a pool.
       await ctx.db.patch(userId, { connectionModeId: 'privacy-reality' });
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.freedom-ws.squads',
-        value: JSON.stringify(['sq-freedom-ws']),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-ws',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['sq-freedom-ws'] }),
         updatedAt: Date.now(),
       });
       await ctx.db.insert('backendServers', {
@@ -1413,9 +1422,10 @@ describe('mode gates on placement-less backends', () => {
     await t.run(async (ctx) => {
       // Member sits on privacy-reality (unbound); only freedom-ws has a pool.
       await ctx.db.patch(userId, { connectionModeId: 'privacy-reality' });
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.freedom-ws.squads',
-        value: JSON.stringify(['11111111-2222-3333-4444-555555555555']),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-ws',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['11111111-2222-3333-4444-555555555555'] }),
         updatedAt: Date.now(),
       });
       await ctx.db.insert('appSettings', {

--- a/convex/account.ts
+++ b/convex/account.ts
@@ -24,7 +24,6 @@ import {
   resolveTrafficLimitBytes,
   type UsageSeries,
 } from './lib/backends/types';
-import { canonicalModeId } from './lib/connectionModes';
 import { backendIdValidator, type BackendId } from './lib/backendIds';
 import { capabilitiesOf } from './lib/backends/capabilities';
 
@@ -350,20 +349,8 @@ export const getAccountView = internalAction({
 
     // Member's chosen connection mode (or the catalog default) — surfaced so the
     // client renders the selected transport server-authoritatively.
-    //
-    // A member still holding a PRE-RENAME id (`evade` / `privacy`) is migrated
-    // here, lazily: the mutation is a no-op unless the stored value is legacy, so
-    // this costs nothing on the account view's 60s refetch. Without it the client
-    // received an id that publicConfig no longer lists and rendered it as a raw
-    // "evade" chip. Belt and braces: the value is canonicalized for THIS response
-    // even if the write is skipped, so the client never sees a legacy id.
-    const healed: string | null = await ctx.runMutation(internal.users.canonicalizeConnectionMode, {
-      userId,
-    });
     const connectionModeId =
-      healed ??
-      (user.connectionModeId ? canonicalModeId(user.connectionModeId) : null) ??
-      (await ctx.runQuery(internal.connectionModes.defaultId, {}));
+      user.connectionModeId ?? (await ctx.runQuery(internal.connectionModes.defaultId, {}));
     const currentMode = await ctx.runQuery(internal.connectionModes.memberMode, {
       modeId: connectionModeId,
       backend: tier.backend,

--- a/convex/connectionModes.test.ts
+++ b/convex/connectionModes.test.ts
@@ -312,6 +312,121 @@ describe('memberMode', () => {
   });
 });
 
+describe('validateMemberChoice (the pre-issuance preference gate)', () => {
+  async function seedMember(
+    t: ReturnType<typeof convexTest>,
+    backend: 'remnawave' | 'outline',
+  ): Promise<Id<'users'>> {
+    const tierId: Id<'tiers'> = await t.run((ctx) =>
+      ctx.db.insert('tiers', {
+        slug: `free-${backend}`,
+        name: 'Free',
+        backend,
+        monthlyTrafficGb: 50,
+        deviceLimit: 1,
+        hwidLimit: 1,
+        hwidEnabled: true,
+        trafficStrategy: 'MONTH',
+        isDefaultFree: backend === 'remnawave',
+        isActive: true,
+        priority: 0,
+        expirationDaysAfterMembershipLapse: 0,
+        updatedAt: Date.now(),
+      }),
+    );
+    return t.run((ctx) =>
+      ctx.db.insert('users', { tierId, status: 'active', updatedAt: Date.now() }),
+    );
+  }
+
+  test('accepts an enabled, bound mode on the member’s backend', async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedMember(t, 'remnawave');
+    await bindPool(t, 'freedom-ws', [SQUAD]);
+    const out = await t.query(internal.connectionModes.validateMemberChoice, {
+      userId,
+      modeId: 'freedom-ws',
+    });
+    expect(out).toEqual({ ok: true, modeId: 'freedom-ws' });
+  });
+
+  test('rejects a DISABLED mode even while its pool is still bound', async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedMember(t, 'remnawave');
+    await t.mutation(internal.seed.seedConnectionModes, {});
+    await bindPool(t, 'freedom-ws', [SQUAD]);
+    await bindPool(t, 'privacy-reality', [SQUAD]);
+    await t.mutation(internal.connectionModes.updateMode, {
+      slug: 'privacy-reality',
+      enabled: false,
+    });
+    const out = await t.query(internal.connectionModes.validateMemberChoice, {
+      userId,
+      modeId: 'privacy-reality',
+    });
+    expect(out).toEqual({ ok: false, code: 'unknown_mode' });
+  });
+
+  test('rejects an unbound mode while another IS available on that backend', async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedMember(t, 'remnawave');
+    await bindPool(t, 'freedom-ws', [SQUAD]);
+    const out = await t.query(internal.connectionModes.validateMemberChoice, {
+      userId,
+      modeId: 'privacy-reality', // enabled but unbound
+    });
+    expect(out).toEqual({ ok: false, code: 'unavailable' });
+  });
+
+  test('bring-up allowance: nothing available on the backend → an enabled mode still records', async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedMember(t, 'remnawave');
+    const out = await t.query(internal.connectionModes.validateMemberChoice, {
+      userId,
+      modeId: 'freedom-ws',
+    });
+    expect(out).toEqual({ ok: true, modeId: 'freedom-ws' });
+  });
+
+  test('judges against the MEMBER’s backend: outline member, remnawave-only mode rejected; an outline-applicable mode accepted despite remnawave pools', async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedMember(t, 'outline');
+    await t.mutation(internal.seed.seedConnectionModes, {});
+    await bindPool(t, 'freedom-ws', [SQUAD]);
+    // remnawave-only mode → not applicable to an outline member.
+    const wrongBackend = await t.query(internal.connectionModes.validateMemberChoice, {
+      userId,
+      modeId: 'freedom-ws',
+    });
+    expect(wrongBackend).toEqual({ ok: false, code: 'unknown_mode' });
+    // An outline-applicable mode is trivially available there — the OLD
+    // cross-backend `bound` check refused it whenever any remnawave pool
+    // was bound.
+    await t.mutation(internal.connectionModes.createMode, {
+      slug: 'outline-basic',
+      label: 'Outline Basic',
+      family: 'freedom',
+      deliveryStyle: 'url',
+      backends: ['outline'],
+    });
+    const out = await t.query(internal.connectionModes.validateMemberChoice, {
+      userId,
+      modeId: 'outline-basic',
+    });
+    expect(out).toEqual({ ok: true, modeId: 'outline-basic' });
+  });
+
+  test('unknown mode id and unknown user both reject', async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedMember(t, 'remnawave');
+    const out = await t.query(internal.connectionModes.validateMemberChoice, {
+      userId,
+      modeId: 'no-such-mode',
+    });
+    expect(out).toEqual({ ok: false, code: 'unknown_mode' });
+  });
+});
+
 describe('admin CRUD', () => {
   test('first edit MATERIALIZES the compiled defaults, then applies (no stranded defaults)', async () => {
     const t = convexTest(schema, modules);

--- a/convex/connectionModes.test.ts
+++ b/convex/connectionModes.test.ts
@@ -122,7 +122,7 @@ describe('resolveModeCatalog', () => {
     expect(lost.orphaned).toBe(true);
   });
 
-  test('default ladder: stored pointer → compiled default → legacy pointer canonicalizes', async () => {
+  test('default ladder: stored pointer → compiled default; an unusable pointer falls through', async () => {
     const t = convexTest(schema, modules);
     // Stored pointer respected while its mode is enabled.
     await t.run((ctx) =>
@@ -144,15 +144,15 @@ describe('resolveModeCatalog', () => {
     });
     expect(await t.run((ctx) => resolveDefaultModeId(ctx.db))).toBe(DEFAULT_CONNECTION_MODE);
 
-    // A legacy-id pointer canonicalizes.
+    // A pointer at an id the catalog doesn't know falls through the same way.
     await t.run(async (ctx) => {
       const row = await ctx.db
         .query('appSettings')
         .withIndex('by_key', (q) => q.eq('key', 'connectionMode.default'))
         .unique();
-      await ctx.db.patch(row!._id, { value: JSON.stringify('privacy') });
+      await ctx.db.patch(row!._id, { value: JSON.stringify('no-such-mode') });
     });
-    expect(await t.run((ctx) => resolveDefaultModeId(ctx.db))).toBe('privacy-reality');
+    expect(await t.run((ctx) => resolveDefaultModeId(ctx.db))).toBe(DEFAULT_CONNECTION_MODE);
   });
 });
 
@@ -286,13 +286,8 @@ describe('memberMode', () => {
     });
   });
 
-  test('canonicalizes a legacy id and falls back to the default for null', async () => {
+  test('falls back to the default for null', async () => {
     const t = convexTest(schema, modules);
-    const legacy = await t.query(internal.connectionModes.memberMode, {
-      modeId: 'privacy',
-      backend: 'remnawave',
-    });
-    expect(legacy!.id).toBe('privacy-reality');
     const none = await t.query(internal.connectionModes.memberMode, {
       modeId: null,
       backend: 'remnawave',

--- a/convex/connectionModes.ts
+++ b/convex/connectionModes.ts
@@ -106,6 +106,42 @@ export const memberMode = internalQuery({
   },
 });
 
+/**
+ * Validate a member's PRE-ISSUANCE mode choice (the plain preference set,
+ * POST /api/v1/account/connection-mode) against the member's OWN backend —
+ * the same per-(mode, backend) gate account.switchMode applies, so a choice
+ * that switch-mode would refuse can't sneak in through the preference route
+ * (a disabled-but-still-pooled mode, or a mode from another backend; both
+ * would later wedge the member on the effective-mode regenerate gate).
+ * One deliberate difference: the bring-up allowance — while NO mode is
+ * available on the member's backend (nothing bound yet), an enabled +
+ * applicable choice is still recorded so signup works on a fresh deploy
+ * (issuance fail-softs + audits, WS1).
+ */
+export const validateMemberChoice = internalQuery({
+  args: { userId: v.id('users'), modeId: v.string() },
+  handler: async (
+    ctx,
+    { userId, modeId },
+  ): Promise<
+    { ok: true; modeId: string } | { ok: false; code: 'unknown_mode' | 'unavailable' }
+  > => {
+    const user = await ctx.db.get(userId);
+    const tier = user ? await ctx.db.get(user.tierId) : null;
+    if (!tier) return { ok: false, code: 'unknown_mode' };
+    const { modes } = await resolveCatalogWithAvailability(ctx.db);
+    const chosen = modes.find((m) => m.id === modeId);
+    if (!chosen || !chosen.enabled || !chosen.backends.includes(tier.backend)) {
+      return { ok: false, code: 'unknown_mode' };
+    }
+    if (!chosen.availableBackends.includes(tier.backend)) {
+      const anyAvailableHere = modes.some((m) => m.availableBackends.includes(tier.backend));
+      if (anyAvailableHere) return { ok: false, code: 'unavailable' };
+    }
+    return { ok: true, modeId: chosen.id };
+  },
+});
+
 // --- generic placement dispatch -------------------------------------------------
 
 /** The (placement, server) pair a NEW key on `backend` issues into — the

--- a/convex/connectionModes.ts
+++ b/convex/connectionModes.ts
@@ -18,7 +18,6 @@ import {
   BUILT_IN_MODE_SLUGS,
   CONNECTION_MODE_DEFAULT_KEY,
   MODE_SLUG_RE,
-  canonicalModeId,
   resolveDefaultModeId,
   resolveModeCatalog,
   type DeliveryStyle,
@@ -79,15 +78,14 @@ export const memberMode = internalQuery({
   },
   handler: async (ctx, { modeId, backend }) => {
     const { families, modes } = await resolveCatalogWithAvailability(ctx.db);
-    const stored = modeId ? canonicalModeId(modeId) : null;
     const effective =
-      (stored ? modes.find((m) => m.id === stored) : undefined) ?? modes.find((m) => m.isDefault);
+      (modeId ? modes.find((m) => m.id === modeId) : undefined) ?? modes.find((m) => m.isDefault);
     if (!effective) {
       // Deleted-from-catalog id on an empty-ish catalog: ship a minimal echo so
       // the client still has a stable id + a sane delivery default.
-      return stored
+      return modeId
         ? {
-            id: stored,
+            id: modeId,
             deliveryStyle: 'url' as DeliveryStyle,
             label: null,
             description: null,
@@ -124,7 +122,7 @@ export const resolveIssueTarget = internalQuery({
     rand: v.optional(v.number()),
   },
   handler: (ctx, { backend, modeId, location, onlyServerId, rand }) =>
-    resolverFor(backend).resolveTarget(ctx.db, modeId ? canonicalModeId(modeId) : null, {
+    resolverFor(backend).resolveTarget(ctx.db, modeId, {
       location: location ?? null,
       onlyServerId: (onlyServerId as string | null | undefined) ?? null,
       rand: typeof rand === 'number' ? () => rand : undefined,
@@ -134,8 +132,7 @@ export const resolveIssueTarget = internalQuery({
 /** The re-issue anti-downgrade gate for `backend` (see PlacementResolver). */
 export const effectiveGate = internalQuery({
   args: { backend: backendIdValidator, modeId: v.union(v.string(), v.null()) },
-  handler: (ctx, { backend, modeId }) =>
-    resolverFor(backend).effectiveGate(ctx.db, modeId ? canonicalModeId(modeId) : null),
+  handler: (ctx, { backend, modeId }) => resolverFor(backend).effectiveGate(ctx.db, modeId),
 });
 
 // --- placement binding (admin:servers:write surface) ---------------------------
@@ -174,8 +171,7 @@ export const setModePlacements = internalMutation({
     const known = new Set(modes.map((m) => m.id));
 
     let applied = 0;
-    for (const rawId of Object.keys(entries)) {
-      const slug = canonicalModeId(rawId);
+    for (const slug of Object.keys(entries)) {
       if (!known.has(slug)) continue; // unknown ids are ignored (never an error)
       const existing = await ctx.db
         .query('modePlacements')
@@ -183,7 +179,7 @@ export const setModePlacements = internalMutation({
         .unique();
       let nextConfig: string | null;
       try {
-        nextConfig = resolver.applyConfigPatch(existing?.config ?? null, entries[rawId]);
+        nextConfig = resolver.applyConfigPatch(existing?.config ?? null, entries[slug]);
       } catch (e) {
         throw new ConvexError({
           code: 'validation',

--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -1432,10 +1432,14 @@ describe('connection-mode admin routes', () => {
       scopes: ['admin:servers:write'],
       subjectType: 'service',
     });
+    // The role keys its entries by the PRE-RENAME ids (evade/privacy — see
+    // tasks/providers/fcp/bind_placements.yml); the alias route must map them
+    // onto the current slugs. Pinned with the role's real body, not the
+    // canonical spelling.
     const res = await t.fetch('/api/v1/admin/remnawave/mode-placements', {
       method: 'PATCH',
       headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-      body: JSON.stringify({ modes: { 'freedom-ws': { addSquadUuids: [SQUAD] } } }),
+      body: JSON.stringify({ modes: { evade: { addSquadUuids: [SQUAD] } } }),
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -1454,6 +1458,35 @@ describe('connection-mode admin routes', () => {
       ),
     );
     expect(settingsPools).toHaveLength(0);
+
+    // Canonical ids pass through the alias untouched; when both spellings of
+    // one mode appear in a single body the canonical entry wins.
+    const SQUAD2 = '22222222-3333-4444-5555-666666666666';
+    const SQUAD3 = '33333333-4444-5555-6666-777777777777';
+    const mixed = await t.fetch('/api/v1/admin/remnawave/mode-placements', {
+      method: 'PATCH',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        modes: {
+          evade: { squadUuids: [SQUAD3] },
+          'freedom-ws': { squadUuids: [SQUAD2] },
+        },
+      }),
+    });
+    expect(mixed.status).toBe(200);
+    const after = await t.run(async (ctx) => ctx.db.query('modePlacements').collect());
+    expect(after).toHaveLength(1);
+    expect(JSON.parse(after[0]!.config)).toEqual({ squadUuids: [SQUAD2] });
+
+    // The node-teardown detach path (removeSquadUuids under the legacy id).
+    const detach = await t.fetch('/api/v1/admin/remnawave/mode-placements', {
+      method: 'PATCH',
+      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ modes: { evade: { removeSquadUuids: [SQUAD2] } } }),
+    });
+    expect(detach.status).toBe(200);
+    const detached = await t.run(async (ctx) => ctx.db.query('modePlacements').collect());
+    expect(JSON.parse(detached[0]!.config)).toEqual({ squadUuids: [] });
   });
 
   test('generic per-backend placement route: PATCH + GET summaries; placement-less backend 400s', async () => {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1135,25 +1135,30 @@ http.route({
     if (!member) return errorJson('auth.unauthenticated', 'Authentication required', 401);
     const body = await readJson<{ modeId?: string }>(req);
     const modeId = typeof body.modeId === 'string' ? body.modeId : '';
-    // Validated against the LIVE catalog (the compiled sync guard is gone with
-    // the compiled catalog).
-    const modes = await ctx.runQuery(internal.connectionModes.list, {});
-    const chosen = modes.find((m) => m.id === modeId);
-    if (!chosen) {
+    if (!modeId || modeId.length > 64) {
       return errorJson('validation', 'unknown connection mode', 400);
     }
-    // Defense-in-depth (the picker already disables unbound modes, and issuance
-    // falls back so a stored unbound preference can't mint a dead key): refuse to
-    // persist an unbound mode when a bound alternative exists. Allowed on an
-    // all-unbound (bring-up) deploy so signup can still record the default. (WS1.)
-    if (!chosen.bound && modes.some((m) => m.bound)) {
-      return errorJson('validation', 'This connection mode is not available yet.', 400);
+    // Validated per-(mode, MEMBER's backend) against the live catalog — the
+    // same gate switch-mode applies (enabled + applicable + bound where the
+    // backend has a placement concept), with the WS1 bring-up allowance so
+    // signup can still record an enabled mode on an all-unbound deploy. The
+    // old cross-backend `bound` check let a disabled-but-pooled mode (or a
+    // wrong-backend mode) be persisted, and wrongly refused a placement-less
+    // backend's own modes whenever any Remnawave pool was bound.
+    const verdict = await ctx.runQuery(internal.connectionModes.validateMemberChoice, {
+      userId: member.userId,
+      modeId,
+    });
+    if (!verdict.ok) {
+      return verdict.code === 'unavailable'
+        ? errorJson('validation', 'This connection mode is not available yet.', 400)
+        : errorJson('validation', 'unknown connection mode', 400);
     }
     await ctx.runMutation(internal.users.setConnectionMode, {
       userId: member.userId,
-      modeId: chosen.id,
+      modeId: verdict.modeId,
     });
-    return json({ ok: true, modeId: chosen.id });
+    return json({ ok: true, modeId: verdict.modeId });
   }),
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -3286,6 +3286,17 @@ http.route({
 // (PATCH /api/v1/admin/backends/remnawave/mode-placements, phase 3): the
 // Ansible role calls THIS path with this exact body/response shape, so it
 // keeps working byte-identically while the role migrates at leisure.
+//
+// The role also still keys its entries by the PRE-RENAME mode ids
+// (evade/privacy — tasks/providers/fcp/bind_placements.yml and the node
+// teardown detach), so this route maps them onto the current slugs before
+// delegating. The map lives HERE and only here: it is part of the alias
+// contract and is deleted together with the route once the role migrates.
+// When both spellings of a mode appear in one body, the canonical entry wins.
+const ANSIBLE_LEGACY_PLACEMENT_IDS: Readonly<Record<string, string>> = {
+  evade: 'freedom-ws',
+  privacy: 'privacy-reality',
+};
 http.route({
   path: '/api/v1/admin/remnawave/mode-placements',
   method: 'PATCH',
@@ -3293,11 +3304,24 @@ http.route({
     const admin = await resolveAdmin(ctx, req, 'admin:servers:write');
     if (!admin) return ADMIN_UNAUTH();
     const body = await readJson<Record<string, unknown>>(req);
+    const rawModes =
+      body && typeof body.modes === 'object' && body.modes !== null
+        ? (body.modes as Record<string, unknown>)
+        : {};
+    const modes: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(rawModes)) {
+      const canonical = ANSIBLE_LEGACY_PLACEMENT_IDS[key];
+      if (canonical) {
+        if (!(canonical in rawModes)) modes[canonical] = entry;
+      } else {
+        modes[key] = entry;
+      }
+    }
     try {
       return json(
         await ctx.runMutation(internal.connectionModes.setModePlacements, {
           backend: 'remnawave',
-          patch: body,
+          patch: { ...body, modes },
           actorAdminId: admin.adminUserId,
         }),
       );

--- a/convex/lib/connectionModes.ts
+++ b/convex/lib/connectionModes.ts
@@ -22,11 +22,6 @@
  * module never reads a placement store. Admin label/description override the
  * SPA's compiled i18n (null → i18n for built-in slugs, humanized slug
  * otherwise); publicConfig ships copy + availability, never a placement.
- *
- * LEGACY (drop in deploy 2): `LEGACY_MODE_ID_MAP` + `canonicalModeId` map the
- * pre-rename ids (evade/privacy) onto their successors at the read points,
- * covering the window until seed:migrateLegacyModeUserIds has rewritten every
- * user row.
  */
 import type { DatabaseReader } from '../_generated/server';
 import type { Doc } from '../_generated/dataModel';
@@ -106,18 +101,6 @@ export const BUILT_IN_MODE_SLUGS: ReadonlySet<string> = new Set(
   DEFAULT_CONNECTION_MODES.map((m) => m.slug),
 );
 
-/** Legacy id -> current id (pre-2026-07 catalog). Read-point shim ONLY —
- *  deleted in deploy 2 once seed:migrateLegacyModeUserIds has run live. */
-export const LEGACY_MODE_ID_MAP: Readonly<Record<string, string>> = {
-  evade: 'freedom-ws',
-  privacy: 'privacy-reality',
-} as const;
-
-/** Map a possibly-legacy id onto its current spelling (identity otherwise). */
-export function canonicalModeId(v: string): string {
-  return LEGACY_MODE_ID_MAP[v] ?? v;
-}
-
 /** The wire id everywhere (users.connectionModeId, matrix cells, audits). */
 export const MODE_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,31}$/;
 
@@ -176,7 +159,7 @@ async function readDefaultPointer(db: DatabaseReader): Promise<string | null> {
   if (!row) return null;
   try {
     const parsed: unknown = JSON.parse(row.value);
-    return typeof parsed === 'string' ? canonicalModeId(parsed) : null;
+    return typeof parsed === 'string' ? parsed : null;
   } catch {
     return null;
   }

--- a/convex/lib/remnawavePlacement.ts
+++ b/convex/lib/remnawavePlacement.ts
@@ -11,29 +11,10 @@
  * resolver registry in lib/placement.ts.
  *
  * The per-mode squad pool lives in the `modePlacements` table, one row per
- * (modeSlug, 'remnawave'), config = {"squadUuids":[...]}. During the deploy-1
- * window (schema pushed, seed not yet run) reads FALL BACK to the pre-refactor
- * appSettings keys (`remnawave.modePlacement.<id>.squads`, legacy mode ids
- * included) — deleted in deploy 2.
+ * (modeSlug, 'remnawave'), config = {"squadUuids":[...]}.
  */
 import type { DatabaseReader } from '../_generated/server';
-import {
-  LEGACY_MODE_ID_MAP,
-  canonicalModeId,
-  resolveDefaultModeId,
-  resolveModeCatalog,
-} from './connectionModes';
-
-// canonical id -> the legacy id whose appSettings pool may still exist during
-// the deploy-1 window (before seedConnectionModes folds it into the table).
-const LEGACY_ALIAS_OF: Readonly<Record<string, string>> = Object.fromEntries(
-  Object.entries(LEGACY_MODE_ID_MAP).map(([legacy, current]) => [current, legacy]),
-);
-
-// The pre-refactor appSettings namespace (read fallback only; deploy 2 drops it).
-const POOL_PREFIX = 'remnawave.modePlacement.';
-const POOL_KEY_SUFFIX = '.squads';
-const MODE_POOL_KEY = (id: string) => `${POOL_PREFIX}${id}${POOL_KEY_SUFFIX}`;
+import { resolveDefaultModeId, resolveModeCatalog } from './connectionModes';
 
 /** Fail-safe parse of a stored squad pool: a JSON array of non-empty strings,
  *  de-duplicated in declaration order; anything else resolves to []. */
@@ -58,34 +39,13 @@ export function poolFromConfig(configJson: string | null | undefined): string[] 
   }
 }
 
-async function readSetting(db: DatabaseReader, key: string): Promise<unknown> {
-  const row = await db
-    .query('appSettings')
-    .withIndex('by_key', (q) => q.eq('key', key))
-    .unique();
-  if (!row) return undefined;
-  try {
-    return JSON.parse(row.value);
-  } catch {
-    return undefined;
-  }
-}
-
-/** The stored pool for ONE canonical slug: the modePlacements row, else (while
- *  the seed hasn't folded it in yet) the appSettings key under the canonical
- *  AND legacy spellings. */
+/** The stored pool for ONE slug: its modePlacements row (missing row = unbound). */
 async function readStoredPool(db: DatabaseReader, slug: string): Promise<string[]> {
   const row = await db
     .query('modePlacements')
     .withIndex('by_mode_backend', (q) => q.eq('modeSlug', slug).eq('backend', 'remnawave'))
     .unique();
-  if (row) return poolFromConfig(row.config);
-  // Deploy-1 window fallback (dropped in deploy 2).
-  const viaSettings = sanitizePool(await readSetting(db, MODE_POOL_KEY(slug)));
-  if (viaSettings.length) return viaSettings;
-  const legacy = LEGACY_ALIAS_OF[slug];
-  if (legacy) return sanitizePool(await readSetting(db, MODE_POOL_KEY(legacy)));
-  return [];
+  return row ? poolFromConfig(row.config) : [];
 }
 
 /** The squad pool a mode issues into. When the member has made no explicit
@@ -100,8 +60,7 @@ export async function resolveModeSquadPool(
 ): Promise<string[]> {
   const { modes } = await resolveModeCatalog(db);
   const known = new Set(modes.map((m) => m.id));
-  const canonical = typeof modeId === 'string' ? canonicalModeId(modeId) : null;
-  const slug = canonical && known.has(canonical) ? canonical : await resolveDefaultModeId(db);
+  const slug = modeId && known.has(modeId) ? modeId : await resolveDefaultModeId(db);
   return readStoredPool(db, slug);
 }
 
@@ -160,8 +119,7 @@ export async function resolveBoundModeCounts(db: DatabaseReader): Promise<Record
 }
 
 /** The set of mode slugs with ≥1 squad bound on Remnawave — feeds per-backend
- *  availability. One index scan over `modePlacements`, plus (deploy-1 window
- *  only) the pre-refactor appSettings namespace with legacy-id canonicalization. */
+ *  availability. One index scan over `modePlacements`. */
 export async function resolveBoundModeIds(db: DatabaseReader): Promise<Set<string>> {
   const bound = new Set<string>();
   const rows = await db
@@ -170,25 +128,6 @@ export async function resolveBoundModeIds(db: DatabaseReader): Promise<Set<strin
     .collect();
   for (const r of rows) {
     if (poolFromConfig(r.config).length > 0) bound.add(r.modeSlug);
-  }
-  // Deploy-1 window fallback: pools still living in appSettings (canonical or
-  // legacy spelling) keep their mode available until the seed folds them in.
-  // A table row for the slug — even an emptied one — takes precedence, so an
-  // admin who deliberately unbinds via the new store isn't overridden.
-  const withRow = new Set(rows.map((r) => r.modeSlug));
-  const legacyRows = await db
-    .query('appSettings')
-    .withIndex('by_key', (q) => q.gte('key', POOL_PREFIX).lt('key', POOL_PREFIX.slice(0, -1) + '/'))
-    .collect();
-  for (const r of legacyRows) {
-    if (!r.key.endsWith(POOL_KEY_SUFFIX)) continue;
-    const id = canonicalModeId(r.key.slice(POOL_PREFIX.length, -POOL_KEY_SUFFIX.length));
-    if (withRow.has(id)) continue;
-    try {
-      if (sanitizePool(JSON.parse(r.value)).length > 0) bound.add(id);
-    } catch {
-      /* malformed → not bound */
-    }
   }
   return bound;
 }
@@ -210,15 +149,14 @@ export async function remnawaveEffectiveGate(
 ): Promise<{ blocked: boolean }> {
   const { modes } = await resolveModeCatalog(db);
   const enabled = new Set(modes.filter((m) => m.enabled).map((m) => m.id));
-  const effective = modeId ? canonicalModeId(modeId) : null;
 
-  const own = await resolveModeSquadPool(db, modeId ?? null);
-  if (own.length > 0 && (effective === null || enabled.has(effective))) {
+  const own = await resolveModeSquadPool(db, modeId);
+  if (own.length > 0 && (modeId === null || enabled.has(modeId))) {
     return { blocked: false };
   }
   // Some OTHER mode is both enabled and bound → refuse rather than downgrade.
   const bound = await resolveBoundModeIds(db);
-  const alternativeExists = [...enabled].some((id) => id !== effective && bound.has(id));
+  const alternativeExists = [...enabled].some((id) => id !== modeId && bound.has(id));
   return { blocked: alternativeExists };
 }
 

--- a/convex/lifecycle.test.ts
+++ b/convex/lifecycle.test.ts
@@ -928,15 +928,16 @@ describe('lifecycle push: re-enable + profile squad (Review #2/#3)', () => {
     const t = convexTest(schema, modules);
     const { memberTierId } = await seedTiers(t);
     const userId = await t.run(async (ctx) => {
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.privacy.squads',
-        value: JSON.stringify(['PRIVACY_SQUAD']),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'privacy-reality',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['PRIVACY_SQUAD'] }),
         updatedAt: Date.now(),
       });
       return ctx.db.insert('users', {
         tierId: memberTierId,
         status: 'active',
-        connectionModeId: 'privacy',
+        connectionModeId: 'privacy-reality',
         membershipExpiresAt: Date.now() + 30 * DAY,
         updatedAt: Date.now(),
       });
@@ -959,7 +960,7 @@ describe('lifecycle push: re-enable + profile squad (Review #2/#3)', () => {
       ctx.db.insert('users', {
         tierId: memberTierId,
         status: 'active',
-        connectionModeId: 'evade',
+        connectionModeId: 'freedom-ws',
         membershipExpiresAt: Date.now() + 30 * DAY,
         updatedAt: Date.now(),
       }),
@@ -1010,9 +1011,10 @@ describe('lifecycle push: re-enable + profile squad (Review #2/#3)', () => {
     const t = convexTest(schema, modules);
     const { memberTierId } = await seedTiers(t);
     const userId = await t.run(async (ctx) => {
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.privacy.squads',
-        value: JSON.stringify(['SQUAD_A', 'SQUAD_B']),
+      await ctx.db.insert('modePlacements', {
+        modeSlug: 'privacy-reality',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['SQUAD_A', 'SQUAD_B'] }),
         updatedAt: Date.now(),
       });
       const serverId = await ctx.db.insert('backendServers', {
@@ -1048,7 +1050,7 @@ describe('lifecycle push: re-enable + profile squad (Review #2/#3)', () => {
       return ctx.db.insert('users', {
         tierId: memberTierId,
         status: 'active',
-        connectionModeId: 'privacy',
+        connectionModeId: 'privacy-reality',
         membershipExpiresAt: Date.now() + 30 * DAY,
         updatedAt: Date.now(),
       });
@@ -1066,7 +1068,7 @@ describe('lifecycle push: re-enable + profile squad (Review #2/#3)', () => {
       ctx.db.insert('users', {
         tierId: memberTierId,
         status: 'active',
-        connectionModeId: 'privacy',
+        connectionModeId: 'privacy-reality',
         membershipExpiresAt: Date.now() + 30 * DAY,
         updatedAt: Date.now(),
       }),
@@ -1108,7 +1110,7 @@ describe('lifecycle push: re-enable + profile squad (Review #2/#3)', () => {
       ctx.db.insert('users', {
         tierId: memberTierId,
         status: 'active',
-        connectionModeId: 'privacy',
+        connectionModeId: 'privacy-reality',
         membershipExpiresAt: Date.now() + 30 * DAY,
         updatedAt: Date.now(),
       }),

--- a/convex/remnawavePlacement.test.ts
+++ b/convex/remnawavePlacement.test.ts
@@ -205,7 +205,21 @@ describe('remnawaveGetNodeStats (provider aggregation)', () => {
 });
 
 describe('resolveBoundModeCounts', () => {
-  test('returns per-mode pool sizes (never UUIDs); unbound = 0; legacy aliases excluded', async () => {
+  test('returns per-mode pool sizes (never UUIDs); unbound = 0', async () => {
+    const t = convexTest(schema, modules);
+    await t.run((ctx) =>
+      ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-ws',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['sq-1', 'sq-2', 'sq-3'] }),
+        updatedAt: Date.now(),
+      }),
+    );
+    const counts = await t.run((ctx) => resolveBoundModeCounts(ctx.db));
+    expect(counts).toEqual({ 'freedom-ws': 3, 'freedom-reality': 0, 'privacy-reality': 0 });
+  });
+
+  test('a stale pre-refactor appSettings pool is IGNORED (the table is the only store)', async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
       await ctx.db.insert('appSettings', {
@@ -215,20 +229,10 @@ describe('resolveBoundModeCounts', () => {
       });
     });
     const counts = await t.run((ctx) => resolveBoundModeCounts(ctx.db));
-    expect(counts).toEqual({ 'freedom-ws': 3, 'freedom-reality': 0, 'privacy-reality': 0 });
-  });
-
-  test('counts a pre-migration pool under its SUCCESSOR id', async () => {
-    const t = convexTest(schema, modules);
-    await t.run(async (ctx) => {
-      await ctx.db.insert('appSettings', {
-        key: 'remnawave.modePlacement.evade.squads',
-        value: JSON.stringify(['sq-1', 'sq-2', 'sq-3']),
-        updatedAt: Date.now(),
-      });
-    });
-    const counts = await t.run((ctx) => resolveBoundModeCounts(ctx.db));
-    expect(counts).toEqual({ 'freedom-ws': 3, 'freedom-reality': 0, 'privacy-reality': 0 });
+    expect(counts).toEqual({ 'freedom-ws': 0, 'freedom-reality': 0, 'privacy-reality': 0 });
+    expect(await t.run((ctx) => resolveModeSquadPool(ctx.db, 'freedom-ws'))).toEqual([]);
+    const bound = await t.run(async (ctx) => [...(await resolveBoundModeIds(ctx.db))]);
+    expect(bound).toEqual([]);
   });
 });
 
@@ -272,53 +276,6 @@ async function bindPool(t: ReturnType<typeof convexTest>, modeId: string, squads
     }),
   );
 }
-
-/** Deploy-1 window shape: the pool still lives in the pre-refactor appSettings
- *  key (the seed hasn't folded it in yet). */
-async function bindLegacyPool(t: ReturnType<typeof convexTest>, modeId: string, squads: string[]) {
-  await t.run((ctx) =>
-    ctx.db.insert('appSettings', {
-      key: `remnawave.modePlacement.${modeId}.squads`,
-      value: JSON.stringify(squads),
-      updatedAt: Date.now(),
-    }),
-  );
-}
-
-describe('deploy-1 window: appSettings pool fallback', () => {
-  test('a pool still under the pre-refactor key (even a LEGACY id) resolves + reads bound', async () => {
-    const t = convexTest(schema, modules);
-    // The seed hasn't folded the pools into modePlacements yet: canonical-key
-    // and legacy-key appSettings pools must both keep working.
-    await bindLegacyPool(t, 'privacy-reality', ['sq-priv']);
-    await bindLegacyPool(t, 'evade', ['sq-ws']); // pre-rename spelling
-    expect(await t.run((ctx) => resolveModeSquadPool(ctx.db, 'privacy-reality'))).toEqual([
-      'sq-priv',
-    ]);
-    expect(await t.run((ctx) => resolveModeSquadPool(ctx.db, 'freedom-ws'))).toEqual(['sq-ws']);
-    const bound = await t.run(async (ctx) => [...(await resolveBoundModeIds(ctx.db))]);
-    expect(bound).toContain('privacy-reality');
-    expect(bound).toContain('freedom-ws');
-  });
-
-  test('a modePlacements row wins over a stale appSettings pool (deliberate unbind sticks)', async () => {
-    const t = convexTest(schema, modules);
-    await bindLegacyPool(t, 'freedom-ws', ['sq-old']);
-    // The admin emptied the pool via the NEW store; the dead settings row must
-    // not resurrect it.
-    await t.run((ctx) =>
-      ctx.db.insert('modePlacements', {
-        modeSlug: 'freedom-ws',
-        backend: 'remnawave',
-        config: JSON.stringify({ squadUuids: [] }),
-        updatedAt: Date.now(),
-      }),
-    );
-    expect(await t.run((ctx) => resolveModeSquadPool(ctx.db, 'freedom-ws'))).toEqual([]);
-    const bound = await t.run(async (ctx) => [...(await resolveBoundModeIds(ctx.db))]);
-    expect(bound).not.toContain('freedom-ws');
-  });
-});
 
 describe('resolvePlacementTarget', () => {
   test('pairs the placement with its own panel (least-loaded across panels)', async () => {

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -14,10 +14,7 @@ import {
   CONNECTION_MODE_DEFAULT_KEY,
   DEFAULT_CONNECTION_MODES,
   DEFAULT_CONNECTION_MODE_FAMILIES,
-  LEGACY_MODE_ID_MAP,
-  canonicalModeId,
 } from './lib/connectionModes';
-import { sanitizePool } from './lib/remnawavePlacement';
 
 /** Insert the default-free tier if absent; return its id. */
 export const seedDefaultFreeTier = internalMutation({
@@ -243,66 +240,22 @@ export const refreshDefaultClients = internalMutation({
 });
 
 /**
- * Seed the DB-driven connection-mode catalog (families + leaf modes) and fold
- * the pre-refactor state in. Idempotent; runs at every deploy via seedCutover.
+ * Seed the DB-driven connection-mode catalog (families + leaf modes).
+ * Idempotent; runs at every deploy via seedCutover. Catalog rows are inserted
+ * ONLY while both tables are empty (the clients-seed rule inverted:
+ * table-level, not per-row, so a built-in row an admin deliberately DELETED is
+ * never resurrected by a later deploy).
  *
- * Catalog rows are inserted ONLY while both tables are empty (the clients-seed
- * rule inverted: table-level, not per-row, so a built-in row an admin
- * deliberately DELETED is never resurrected by a later deploy). On that first
- * run the old appSettings state is absorbed into the rows:
- *   - `connectionMode.<id>.label/description/enabled` + the family namespace
- *     (legacy-keyed copies fold onto their successors; a current-key value
- *     wins over a legacy-key one),
- *   - `connectionMode.default` is canonicalized in place (the pointer key
- *     itself stays live — it is still the default-mode store),
- *   - `remnawave.modePlacement.<id>.squads` pools become `modePlacements`
- *     rows (canonical slug; an existing row wins — insert-if-missing).
- * The absorbed appSettings rows are LEFT IN PLACE (dead) for deploy-1
- * rollback safety; a deploy-2 cleanup mutation deletes them.
+ * The 2026-07-28 migration release (deploy 1) additionally absorbed the
+ * pre-refactor appSettings state (copy/enabled overrides, placement pools,
+ * legacy mode ids) on that first run — a deployment coming from the old
+ * catalog MUST pass through that release before this one; jumping straight
+ * here starts from the compiled defaults.
  */
 export const seedConnectionModes = internalMutation({
   args: {},
-  handler: async (
-    ctx,
-  ): Promise<{ familiesInserted: number; modesInserted: number; poolsMoved: number }> => {
+  handler: async (ctx): Promise<{ familiesInserted: number; modesInserted: number }> => {
     const now = Date.now();
-    const readSetting = async (key: string): Promise<unknown> => {
-      const row = await ctx.db
-        .query('appSettings')
-        .withIndex('by_key', (q) => q.eq('key', key))
-        .unique();
-      if (!row) return undefined;
-      try {
-        return JSON.parse(row.value);
-      } catch {
-        return undefined;
-      }
-    };
-    // Absorb a copy override for `slug`, preferring the current key, falling
-    // back to the legacy spelling's key.
-    const legacyOf: Record<string, string> = {};
-    for (const [legacy, current] of Object.entries(LEGACY_MODE_ID_MAP)) legacyOf[current] = legacy;
-    const absorbString = async (prefix: string, slug: string, field: string) => {
-      const current = await readSetting(`${prefix}.${slug}.${field}`);
-      if (typeof current === 'string' && current.trim()) return current;
-      const legacy = legacyOf[slug];
-      if (legacy) {
-        const viaLegacy = await readSetting(`${prefix}.${legacy}.${field}`);
-        if (typeof viaLegacy === 'string' && viaLegacy.trim()) return viaLegacy;
-      }
-      return undefined;
-    };
-    const absorbBool = async (prefix: string, slug: string, fallback: boolean) => {
-      const current = await readSetting(`${prefix}.${slug}.enabled`);
-      if (typeof current === 'boolean') return current;
-      const legacy = legacyOf[slug];
-      if (legacy) {
-        const viaLegacy = await readSetting(`${prefix}.${legacy}.enabled`);
-        if (typeof viaLegacy === 'boolean') return viaLegacy;
-      }
-      return fallback;
-    };
-
     let familiesInserted = 0;
     let modesInserted = 0;
     const [famAny, modeAny] = await Promise.all([
@@ -313,10 +266,8 @@ export const seedConnectionModes = internalMutation({
       for (const f of DEFAULT_CONNECTION_MODE_FAMILIES) {
         await ctx.db.insert('connectionModeFamilies', {
           slug: f.slug,
-          label: await absorbString('connectionModeFamily', f.slug, 'label'),
-          description: await absorbString('connectionModeFamily', f.slug, 'description'),
           iconId: f.iconId,
-          enabled: await absorbBool('connectionModeFamily', f.slug, f.enabled),
+          enabled: f.enabled,
           order: f.order,
           updatedAt: now,
         });
@@ -327,9 +278,7 @@ export const seedConnectionModes = internalMutation({
           slug: m.slug,
           familySlug: m.familySlug,
           deliveryStyle: m.deliveryStyle,
-          label: await absorbString('connectionMode', m.slug, 'label'),
-          description: await absorbString('connectionMode', m.slug, 'description'),
-          enabled: await absorbBool('connectionMode', m.slug, m.enabled),
+          enabled: m.enabled,
           isFamilyDefault: m.isFamilyDefault,
           isCensorshipRecommended: m.isCensorshipRecommended,
           backends: [...m.backends],
@@ -339,107 +288,61 @@ export const seedConnectionModes = internalMutation({
         modesInserted++;
       }
     }
-
-    // Canonicalize the default pointer in place (idempotent).
-    const defaultRow = await ctx.db
-      .query('appSettings')
-      .withIndex('by_key', (q) => q.eq('key', CONNECTION_MODE_DEFAULT_KEY))
-      .unique();
-    if (defaultRow) {
-      try {
-        const parsed: unknown = JSON.parse(defaultRow.value);
-        if (typeof parsed === 'string' && LEGACY_MODE_ID_MAP[parsed]) {
-          await ctx.db.patch(defaultRow._id, {
-            value: JSON.stringify(LEGACY_MODE_ID_MAP[parsed]),
-            updatedAt: now,
-          });
-        }
-      } catch {
-        /* malformed → resolution already falls back to the compiled default */
-      }
-    }
-
-    // Move the Remnawave placement pools into modePlacements rows. Canonical
-    // slugs; fold canonical keys FIRST so a legacy key never shadows one, and an
-    // existing table row always wins (a re-run, or an admin/Ansible that already
-    // wrote the new store). Source rows stay in place (deploy-2 deletes them).
-    let poolsMoved = 0;
-    const POOL_PREFIX = 'remnawave.modePlacement.';
-    const POOL_SUFFIX = '.squads';
-    const poolRows = await ctx.db
-      .query('appSettings')
-      .withIndex('by_key', (q) =>
-        q.gte('key', POOL_PREFIX).lt('key', POOL_PREFIX.slice(0, -1) + '/'),
-      )
-      .collect();
-    const parsedPools = poolRows
-      .filter((r) => r.key.endsWith(POOL_SUFFIX))
-      .map((r) => {
-        const rawId = r.key.slice(POOL_PREFIX.length, -POOL_SUFFIX.length);
-        let pool: string[] = [];
-        try {
-          pool = sanitizePool(JSON.parse(r.value));
-        } catch {
-          /* malformed → skip */
-        }
-        return {
-          slug: canonicalModeId(rawId),
-          canonicalKey: canonicalModeId(rawId) === rawId,
-          pool,
-        };
-      })
-      .filter((e) => e.pool.length > 0)
-      .sort((a, b) => Number(b.canonicalKey) - Number(a.canonicalKey));
-    for (const entry of parsedPools) {
-      const existing = await ctx.db
-        .query('modePlacements')
-        .withIndex('by_mode_backend', (q) =>
-          q.eq('modeSlug', entry.slug).eq('backend', 'remnawave'),
-        )
-        .unique();
-      if (existing) continue;
-      await ctx.db.insert('modePlacements', {
-        modeSlug: entry.slug,
-        backend: 'remnawave',
-        config: JSON.stringify({ squadUuids: entry.pool }),
-        updatedAt: now,
-      });
-      poolsMoved++;
-    }
-
-    return { familiesInserted, modesInserted, poolsMoved };
+    return { familiesInserted, modesInserted };
   },
 });
 
+// The pre-rename mode ids (dropped from the wire 2026-07-28). Only the cleanup
+// guard below still knows them.
+const LEGACY_MODE_IDS = ['evade', 'privacy'] as const;
+
 /**
- * Rewrite users still holding a PRE-RENAME connection-mode id (evade/privacy)
- * onto the successor slug. Paged (no index on connectionModeId — a bounded
- * _creationTime scan); seedCutover loops it to completion at every deploy, so
- * the migration needs no operator step and a converged deploy pays one cheap
- * page scan. Deleted (with the LEGACY_MODE_ID_MAP shim) in deploy 2.
+ * ONE-SHOT operator cleanup (deploy 2 of the DB-driven mode catalog): delete
+ * the appSettings rows the 2026-07-28 migration absorbed into tables and left
+ * dead for rollback safety:
+ *   - `connectionMode.<id>.*` copy/enabled overrides — the DEFAULT POINTER
+ *     `connectionMode.default` is KEPT (still the live default-mode store),
+ *   - `connectionModeFamily.*` family overrides,
+ *   - `remnawave.modePlacement.*` squad pools (now `modePlacements` rows).
+ *
+ * GUARDED: refuses while any user still holds a pre-rename mode id — that
+ * means this deployment never ran the deploy-1 migration (it jumped straight
+ * to post-shim code); deploy the 2026-07-28 release first so its seed rewrites
+ * those rows. Idempotent: a re-run deletes nothing and returns 0.
+ *
+ * Run through the stack's deployer container:
+ *   bunx convex run seed:cleanupLegacyModeSettings '{}'
  */
-export const migrateLegacyModeUserIds = internalMutation({
-  args: { limit: v.optional(v.number()), cursor: v.optional(v.number()) },
-  handler: async (
-    ctx,
-    { limit, cursor },
-  ): Promise<{ usersUpdated: number; nextCursor: number | null }> => {
-    const now = Date.now();
-    const pageSize = Math.min(Math.max(limit ?? 500, 1), 2000);
-    let usersUpdated = 0;
-    const page = await ctx.db
-      .query('users')
-      .withIndex('by_creation_time', (q) => (cursor != null ? q.gt('_creationTime', cursor) : q))
-      .take(pageSize);
-    for (const user of page) {
-      const current = user.connectionModeId ? LEGACY_MODE_ID_MAP[user.connectionModeId] : undefined;
-      if (!current) continue;
-      await ctx.db.patch(user._id, { connectionModeId: current, updatedAt: now });
-      usersUpdated++;
+export const cleanupLegacyModeSettings = internalMutation({
+  args: {},
+  handler: async (ctx): Promise<{ deleted: number }> => {
+    for (const legacyId of LEGACY_MODE_IDS) {
+      const holder = await ctx.db
+        .query('users')
+        .withIndex('by_connection_mode', (q) => q.eq('connectionModeId', legacyId))
+        .first();
+      if (holder) {
+        throw new Error(
+          `refusing to clean up: a user still holds the pre-rename mode id "${legacyId}". ` +
+            'This deployment has not run the deploy-1 migration (the 2026-07-28 release ' +
+            'whose seedCutover rewrites legacy user rows) — deploy that release first.',
+        );
+      }
     }
-    const nextCursor =
-      page.length === pageSize ? (page[page.length - 1]?._creationTime ?? null) : null;
-    return { usersUpdated, nextCursor };
+    const prefixes = ['connectionMode.', 'connectionModeFamily.', 'remnawave.modePlacement.'];
+    let deleted = 0;
+    for (const prefix of prefixes) {
+      const rows = await ctx.db
+        .query('appSettings')
+        .withIndex('by_key', (q) => q.gte('key', prefix).lt('key', prefix.slice(0, -1) + '/'))
+        .collect();
+      for (const row of rows) {
+        if (row.key === CONNECTION_MODE_DEFAULT_KEY) continue;
+        await ctx.db.delete(row._id);
+        deleted++;
+      }
+    }
+    return { deleted };
   },
 });
 
@@ -487,8 +390,6 @@ export const seedCutover = internalAction({
     clientsInserted: number;
     modeFamiliesInserted: number;
     modesInserted: number;
-    modePoolsMoved: number;
-    modeUsersUpdated: number;
   }> => {
     const freeTierId = await ctx.runMutation(internal.seed.seedDefaultFreeTier, {});
     const memberTierId = await ctx.runMutation(internal.seed.seedMemberTier, {});
@@ -497,19 +398,6 @@ export const seedCutover = internalAction({
     const clients = await ctx.runMutation(internal.seed.seedClients, {});
     const modes = await ctx.runMutation(internal.seed.seedConnectionModes, {});
     await ctx.runMutation(internal.seed.seedPeerGroups, {});
-    // Loop the paged legacy-id rewrite to completion (an action may chain
-    // mutations): the migration runs itself at deploy, no operator step. A
-    // converged deploy pays one page scan that finds nothing.
-    let modeUsersUpdated = 0;
-    let cursor: number | null = null;
-    do {
-      const page: { usersUpdated: number; nextCursor: number | null } = await ctx.runMutation(
-        internal.seed.migrateLegacyModeUserIds,
-        cursor != null ? { cursor } : {},
-      );
-      modeUsersUpdated += page.usersUpdated;
-      cursor = page.nextCursor;
-    } while (cursor != null);
     return {
       freeTierId,
       memberTierId,
@@ -518,8 +406,6 @@ export const seedCutover = internalAction({
       clientsInserted: clients.inserted,
       modeFamiliesInserted: modes.familiesInserted,
       modesInserted: modes.modesInserted,
-      modePoolsMoved: modes.poolsMoved,
-      modeUsersUpdated,
     };
   },
 });

--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -14,6 +14,7 @@ import {
   CONNECTION_MODE_DEFAULT_KEY,
   DEFAULT_CONNECTION_MODES,
   DEFAULT_CONNECTION_MODE_FAMILIES,
+  resolveModeCatalog,
 } from './lib/connectionModes';
 
 /** Insert the default-free tier if absent; return its id. */
@@ -292,9 +293,12 @@ export const seedConnectionModes = internalMutation({
   },
 });
 
-// The pre-rename mode ids (dropped from the wire 2026-07-28). Only the cleanup
-// guard below still knows them.
-const LEGACY_MODE_IDS = ['evade', 'privacy'] as const;
+// The pre-rename mode ids (dropped from the wire 2026-07-28) and their
+// successors. Only the cleanup mutation below still knows them.
+const LEGACY_MODE_ID_SUCCESSORS: Readonly<Record<string, string>> = {
+  evade: 'freedom-ws',
+  privacy: 'privacy-reality',
+};
 
 /**
  * ONE-SHOT operator cleanup (deploy 2 of the DB-driven mode catalog): delete
@@ -304,19 +308,26 @@ const LEGACY_MODE_IDS = ['evade', 'privacy'] as const;
  *     `connectionMode.default` is KEPT (still the live default-mode store),
  *   - `connectionModeFamily.*` family overrides,
  *   - `remnawave.modePlacement.*` squad pools (now `modePlacements` rows).
+ * It also re-keys any censorship-matrix cells still stored under a pre-rename
+ * mode id (belt and braces for a deployment that ran an EARLY build of the
+ * migration release, before its seed learned the matrix rewrite).
  *
- * GUARDED: refuses while any user still holds a pre-rename mode id — that
- * means this deployment never ran the deploy-1 migration (it jumped straight
- * to post-shim code); deploy the 2026-07-28 release first so its seed rewrites
- * those rows. Idempotent: a re-run deletes nothing and returns 0.
+ * GUARDED, twice — both refusals mean the deploy-1 migration never ran here
+ * (this deployment jumped straight to post-shim code); deploy the 2026-07-28
+ * release first:
+ *   1. refuses while any user still holds a pre-rename mode id;
+ *   2. refuses while a non-empty appSettings squad pool has NO modePlacements
+ *      row for its (successor) slug even though that mode is still in the
+ *      catalog — deleting it would destroy the only copy of the pool.
+ * Idempotent: a re-run deletes nothing and returns 0.
  *
  * Run through the stack's deployer container:
  *   bunx convex run seed:cleanupLegacyModeSettings '{}'
  */
 export const cleanupLegacyModeSettings = internalMutation({
   args: {},
-  handler: async (ctx): Promise<{ deleted: number }> => {
-    for (const legacyId of LEGACY_MODE_IDS) {
+  handler: async (ctx): Promise<{ deleted: number; matrixCellsRekeyed: number }> => {
+    for (const legacyId of Object.keys(LEGACY_MODE_ID_SUCCESSORS)) {
       const holder = await ctx.db
         .query('users')
         .withIndex('by_connection_mode', (q) => q.eq('connectionModeId', legacyId))
@@ -329,6 +340,84 @@ export const cleanupLegacyModeSettings = internalMutation({
         );
       }
     }
+
+    const now = Date.now();
+    // The RESOLVED catalog (compiled-defaults fallback included): on a
+    // deployment whose tables are still empty, the defaults are what issuance
+    // resolves against, so a pool for a default slug is still load-bearing.
+    const catalogSlugs = new Set((await resolveModeCatalog(ctx.db)).modes.map((m) => m.id));
+
+    // Guard 2: verify every still-relevant squad pool was actually absorbed
+    // into `modePlacements` before deleting its appSettings copy. A pool for a
+    // mode the admin has since DELETED from the catalog is dead either way and
+    // does not block; an emptied/absent pool has nothing to lose.
+    const POOL_PREFIX = 'remnawave.modePlacement.';
+    const POOL_SUFFIX = '.squads';
+    const poolRows = await ctx.db
+      .query('appSettings')
+      .withIndex('by_key', (q) =>
+        q.gte('key', POOL_PREFIX).lt('key', POOL_PREFIX.slice(0, -1) + '/'),
+      )
+      .collect();
+    for (const row of poolRows) {
+      if (!row.key.endsWith(POOL_SUFFIX)) continue;
+      let pool: unknown;
+      try {
+        pool = JSON.parse(row.value);
+      } catch {
+        continue; // malformed → nothing to lose
+      }
+      if (!Array.isArray(pool) || !pool.some((s) => typeof s === 'string' && s.trim())) continue;
+      const rawId = row.key.slice(POOL_PREFIX.length, -POOL_SUFFIX.length);
+      const slug = LEGACY_MODE_ID_SUCCESSORS[rawId] ?? rawId;
+      if (!catalogSlugs.has(slug)) continue;
+      const transferred = await ctx.db
+        .query('modePlacements')
+        .withIndex('by_mode_backend', (q) => q.eq('modeSlug', slug).eq('backend', 'remnawave'))
+        .unique();
+      if (!transferred) {
+        throw new Error(
+          `refusing to clean up: the appSettings squad pool for "${rawId}" was never absorbed ` +
+            `into modePlacements (mode "${slug}" has no row) — deleting it would destroy the ` +
+            'only copy. Deploy the 2026-07-28 migration release first, or bind the pool via ' +
+            'Admin -> Remnawave / the placement route before cleaning up.',
+        );
+      }
+    }
+
+    // Re-key censorship-matrix cells still stored under a pre-rename id
+    // (canonical-cell-wins; a legacy spelling that IS a live catalog slug is
+    // never touched). The migration release's seed does this too — this covers
+    // deployments that ran an early build of it.
+    let matrixCellsRekeyed = 0;
+    const matrixRow = await ctx.db
+      .query('appSettings')
+      .withIndex('by_key', (q) => q.eq('key', 'status.censorship'))
+      .unique();
+    if (matrixRow) {
+      try {
+        const parsed: unknown = JSON.parse(matrixRow.value);
+        const rows = (parsed as { rows?: unknown })?.rows;
+        if (Array.isArray(rows)) {
+          for (const r of rows) {
+            const cells = (r as { cells?: Record<string, unknown> })?.cells;
+            if (!cells || typeof cells !== 'object') continue;
+            for (const [legacy, current] of Object.entries(LEGACY_MODE_ID_SUCCESSORS)) {
+              if (!(legacy in cells) || catalogSlugs.has(legacy)) continue;
+              if (!(current in cells)) cells[current] = cells[legacy];
+              delete cells[legacy];
+              matrixCellsRekeyed++;
+            }
+          }
+          if (matrixCellsRekeyed > 0) {
+            await ctx.db.patch(matrixRow._id, { value: JSON.stringify(parsed), updatedAt: now });
+          }
+        }
+      } catch {
+        /* malformed matrix → the status page already fail-safes to empty */
+      }
+    }
+
     const prefixes = ['connectionMode.', 'connectionModeFamily.', 'remnawave.modePlacement.'];
     let deleted = 0;
     for (const prefix of prefixes) {
@@ -342,7 +431,7 @@ export const cleanupLegacyModeSettings = internalMutation({
         deleted++;
       }
     }
-    return { deleted };
+    return { deleted, matrixCellsRekeyed };
   },
 });
 

--- a/convex/seedConnectionModes.test.ts
+++ b/convex/seedConnectionModes.test.ts
@@ -1,10 +1,10 @@
 /// <reference types="vite/client" />
 /**
- * The connection-mode seed + migration centerpiece: fresh-deploy seeding,
- * absorption of the pre-refactor appSettings state (current AND legacy keys,
- * current-beats-legacy), the placement-pool move (existing-row-wins), the paged
- * legacy user-id rewrite, and the idempotency guarantees (double-run = zero
- * writes; admin edits survive every later deploy).
+ * The connection-mode seed (post-migration, deploy-2 shape): fresh-deploy
+ * seeding, the idempotency guarantees (double-run = zero writes; admin edits
+ * survive every later deploy), peer-group conversion, and the guarded one-shot
+ * `cleanupLegacyModeSettings` that deletes the dead appSettings rows the
+ * 2026-07-28 migration absorbed.
  */
 import { convexTest } from 'convex-test';
 import { describe, expect, test } from 'vitest';
@@ -58,7 +58,7 @@ describe('seedConnectionModes: fresh deploy', () => {
   test('inserts the compiled defaults into empty tables', async () => {
     const t = convexTest(schema, modules);
     const out = await t.mutation(internal.seed.seedConnectionModes, {});
-    expect(out).toMatchObject({ familiesInserted: 2, modesInserted: 3, poolsMoved: 0 });
+    expect(out).toMatchObject({ familiesInserted: 2, modesInserted: 3 });
     const fams = await t.run((ctx) => ctx.db.query('connectionModeFamilies').collect());
     const modes = await t.run((ctx) => ctx.db.query('connectionModes').collect());
     expect(fams.map((f) => f.slug).sort()).toEqual(['freedom', 'privacy']);
@@ -82,7 +82,7 @@ describe('seedConnectionModes: fresh deploy', () => {
       pools: await ctx.db.query('modePlacements').collect(),
     }));
     const out2 = await t.mutation(internal.seed.seedConnectionModes, {});
-    expect(out2).toMatchObject({ familiesInserted: 0, modesInserted: 0, poolsMoved: 0 });
+    expect(out2).toMatchObject({ familiesInserted: 0, modesInserted: 0 });
     const snapshot2 = await t.run(async (ctx) => ({
       fams: await ctx.db.query('connectionModeFamilies').collect(),
       modes: await ctx.db.query('connectionModes').collect(),
@@ -110,120 +110,56 @@ describe('seedConnectionModes: fresh deploy', () => {
   });
 });
 
-describe('seedConnectionModes: absorbing pre-refactor appSettings', () => {
-  test('label/description/enabled fold in from current keys', async () => {
+describe('cleanupLegacyModeSettings', () => {
+  test('deletes the absorbed namespaces, keeps the default pointer + unrelated keys; idempotent', async () => {
     const t = convexTest(schema, modules);
     await putSetting(t, 'connectionMode.privacy-reality.label', 'Max privacy');
-    await putSetting(t, 'connectionMode.privacy-reality.description', 'No CDN in the path.');
-    await putSetting(t, 'connectionMode.freedom-reality.enabled', true); // operator lit it up
+    await putSetting(t, 'connectionMode.evade.label', 'Old Evade Label');
+    await putSetting(t, 'connectionMode.freedom-reality.enabled', true);
     await putSetting(t, 'connectionModeFamily.freedom.label', 'Internet Freedom');
-    await t.mutation(internal.seed.seedConnectionModes, {});
-    const modes = await t.run((ctx) => ctx.db.query('connectionModes').collect());
-    const fams = await t.run((ctx) => ctx.db.query('connectionModeFamilies').collect());
-    expect(modes.find((m) => m.slug === 'privacy-reality')).toMatchObject({
-      label: 'Max privacy',
-      description: 'No CDN in the path.',
-    });
-    expect(modes.find((m) => m.slug === 'freedom-reality')!.enabled).toBe(true);
-    expect(fams.find((f) => f.slug === 'freedom')!.label).toBe('Internet Freedom');
-    // Absorbed source rows are LEFT IN PLACE (deploy-1 rollback safety).
-    const leftover = await t.run((ctx) =>
-      ctx.db
-        .query('appSettings')
-        .withIndex('by_key', (q) => q.eq('key', 'connectionMode.privacy-reality.label'))
-        .unique(),
+    await putSetting(t, 'remnawave.modePlacement.evade.squads', ['sq-legacy-ws']);
+    await putSetting(t, 'remnawave.modePlacement.freedom-ws.squads', ['sq-ws']);
+    // Survivors: the live default pointer + neighbors outside the namespaces.
+    await putSetting(t, 'connectionMode.default', 'freedom-ws');
+    await putSetting(t, 'remnawave.nodePlacement.usersOnline_weight', 1);
+    await putSetting(t, 'site.bannerEnabled', false);
+
+    const out = await t.mutation(internal.seed.cleanupLegacyModeSettings, {});
+    expect(out.deleted).toBe(6);
+
+    const keys = await t.run(async (ctx) =>
+      (await ctx.db.query('appSettings').collect()).map((r) => r.key).sort(),
     );
-    expect(leftover).not.toBeNull();
+    expect(keys).toEqual([
+      'connectionMode.default',
+      'remnawave.nodePlacement.usersOnline_weight',
+      'site.bannerEnabled',
+    ]);
+
+    // Idempotent: a re-run deletes nothing.
+    expect((await t.mutation(internal.seed.cleanupLegacyModeSettings, {})).deleted).toBe(0);
   });
 
-  test('legacy-keyed copy folds onto the successor; a current key wins over it', async () => {
+  test('refuses while any user still holds a pre-rename mode id', async () => {
     const t = convexTest(schema, modules);
     await putSetting(t, 'connectionMode.evade.label', 'Old Evade Label');
-    await putSetting(t, 'connectionMode.privacy.label', 'Old Privacy Label');
-    await putSetting(t, 'connectionMode.privacy-reality.label', 'New Privacy Label'); // wins
-    await t.mutation(internal.seed.seedConnectionModes, {});
-    const modes = await t.run((ctx) => ctx.db.query('connectionModes').collect());
-    expect(modes.find((m) => m.slug === 'freedom-ws')!.label).toBe('Old Evade Label');
-    expect(modes.find((m) => m.slug === 'privacy-reality')!.label).toBe('New Privacy Label');
-  });
-
-  test('the default pointer is canonicalized in place', async () => {
-    const t = convexTest(schema, modules);
-    await putSetting(t, 'connectionMode.default', 'privacy'); // legacy id
-    await t.mutation(internal.seed.seedConnectionModes, {});
-    const row = await t.run((ctx) =>
-      ctx.db
-        .query('appSettings')
-        .withIndex('by_key', (q) => q.eq('key', 'connectionMode.default'))
-        .unique(),
+    const legacy = await seedUserWithMode(t, 'evade');
+    await expect(t.mutation(internal.seed.cleanupLegacyModeSettings, {})).rejects.toThrow(
+      /pre-rename mode id "evade"/,
     );
-    expect(JSON.parse(row!.value)).toBe('privacy-reality');
+    // Nothing was deleted on the refused run.
+    const rows = await t.run((ctx) => ctx.db.query('appSettings').collect());
+    expect(rows).toHaveLength(1);
+    // Once the user is off the legacy id, the cleanup proceeds.
+    await t.run((ctx) => ctx.db.patch(legacy, { connectionModeId: 'freedom-ws' }));
+    expect((await t.mutation(internal.seed.cleanupLegacyModeSettings, {})).deleted).toBe(1);
   });
 
-  test('placement pools move to modePlacements rows (canonical slug, legacy key folds, existing row wins)', async () => {
+  test('a current-id or unset user does not trip the guard', async () => {
     const t = convexTest(schema, modules);
-    await putSetting(t, 'remnawave.modePlacement.evade.squads', ['sq-legacy-ws']);
-    await putSetting(t, 'remnawave.modePlacement.privacy-reality.squads', ['sq-priv']);
-    // The admin already wrote the new store for privacy-reality → the seed must not clobber it.
-    await t.run((ctx) =>
-      ctx.db.insert('modePlacements', {
-        modeSlug: 'privacy-reality',
-        backend: 'remnawave',
-        config: JSON.stringify({ squadUuids: ['sq-priv-new-store'] }),
-        updatedAt: Date.now(),
-      }),
-    );
-    const out = await t.mutation(internal.seed.seedConnectionModes, {});
-    expect(out.poolsMoved).toBe(1); // only the evade pool moved
-    const pools = await t.run((ctx) => ctx.db.query('modePlacements').collect());
-    const ws = pools.find((p) => p.modeSlug === 'freedom-ws')!;
-    expect(JSON.parse(ws.config)).toEqual({ squadUuids: ['sq-legacy-ws'] });
-    const priv = pools.find((p) => p.modeSlug === 'privacy-reality')!;
-    expect(JSON.parse(priv.config)).toEqual({ squadUuids: ['sq-priv-new-store'] });
-  });
-
-  test('canonical-key pool wins over a legacy-key pool for the same mode', async () => {
-    const t = convexTest(schema, modules);
-    await putSetting(t, 'remnawave.modePlacement.evade.squads', ['sq-old']);
-    await putSetting(t, 'remnawave.modePlacement.freedom-ws.squads', ['sq-new']);
-    await t.mutation(internal.seed.seedConnectionModes, {});
-    const pools = await t.run((ctx) => ctx.db.query('modePlacements').collect());
-    expect(pools).toHaveLength(1);
-    expect(JSON.parse(pools[0]!.config)).toEqual({ squadUuids: ['sq-new'] });
-  });
-});
-
-describe('migrateLegacyModeUserIds', () => {
-  test('rewrites legacy ids, leaves everything else alone, pages to completion', async () => {
-    const t = convexTest(schema, modules);
-    const legacy1 = await seedUserWithMode(t, 'evade');
-    const legacy2 = await seedUserWithMode(t, 'privacy');
-    const current = await seedUserWithMode(t, 'freedom-ws');
-    const unset = await seedUserWithMode(t, undefined);
-
-    // Page size 1 exercises the cursor loop.
-    let cursor: number | null = null;
-    let total = 0;
-    do {
-      const page: { usersUpdated: number; nextCursor: number | null } = await t.mutation(
-        internal.seed.migrateLegacyModeUserIds,
-        cursor != null ? { cursor, limit: 1 } : { limit: 1 },
-      );
-      total += page.usersUpdated;
-      cursor = page.nextCursor;
-    } while (cursor != null);
-    expect(total).toBe(2);
-
-    await t.run(async (ctx) => {
-      expect((await ctx.db.get(legacy1))!.connectionModeId).toBe('freedom-ws');
-      expect((await ctx.db.get(legacy2))!.connectionModeId).toBe('privacy-reality');
-      expect((await ctx.db.get(current))!.connectionModeId).toBe('freedom-ws');
-      expect((await ctx.db.get(unset))!.connectionModeId).toBeUndefined();
-    });
-
-    // Converged: a re-run finds nothing.
-    const again = await t.mutation(internal.seed.migrateLegacyModeUserIds, {});
-    expect(again).toEqual({ usersUpdated: 0, nextCursor: null });
+    await seedUserWithMode(t, 'freedom-ws');
+    await seedUserWithMode(t, undefined);
+    expect((await t.mutation(internal.seed.cleanupLegacyModeSettings, {})).deleted).toBe(0);
   });
 });
 
@@ -272,18 +208,14 @@ describe('seedPeerGroups', () => {
 });
 
 describe('seedCutover integration', () => {
-  test('one call seeds the catalog AND runs the user rewrite to completion', async () => {
+  test('one call seeds the catalog; a second deploy is zero work', async () => {
     const t = convexTest(schema, modules);
-    const legacy = await seedUserWithMode(t, 'evade');
     const out = await t.action(internal.seed.seedCutover, {});
     expect(out.modesInserted).toBe(3);
-    expect(out.modeUsersUpdated).toBe(1);
-    await t.run(async (ctx) => {
-      expect((await ctx.db.get(legacy))!.connectionModeId).toBe('freedom-ws');
-    });
+    expect(out.modeFamiliesInserted).toBe(2);
     // Second deploy: fully converged, zero work.
     const out2 = await t.action(internal.seed.seedCutover, {});
     expect(out2.modesInserted).toBe(0);
-    expect(out2.modeUsersUpdated).toBe(0);
+    expect(out2.modeFamiliesInserted).toBe(0);
   });
 });

--- a/convex/seedConnectionModes.test.ts
+++ b/convex/seedConnectionModes.test.ts
@@ -123,6 +123,15 @@ describe('cleanupLegacyModeSettings', () => {
     await putSetting(t, 'connectionMode.default', 'freedom-ws');
     await putSetting(t, 'remnawave.nodePlacement.usersOnline_weight', 1);
     await putSetting(t, 'site.bannerEnabled', false);
+    // A migrated deployment: the pool already lives in the new store.
+    await t.run((ctx) =>
+      ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-ws',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['sq-ws'] }),
+        updatedAt: Date.now(),
+      }),
+    );
 
     const out = await t.mutation(internal.seed.cleanupLegacyModeSettings, {});
     expect(out.deleted).toBe(6);
@@ -160,6 +169,103 @@ describe('cleanupLegacyModeSettings', () => {
     await seedUserWithMode(t, 'freedom-ws');
     await seedUserWithMode(t, undefined);
     expect((await t.mutation(internal.seed.cleanupLegacyModeSettings, {})).deleted).toBe(0);
+  });
+
+  test('refuses while a non-empty pool was never absorbed into modePlacements', async () => {
+    const t = convexTest(schema, modules);
+    // A pool under the LEGACY spelling whose successor mode is live (compiled
+    // defaults count — this is exactly the skipped-deploy-1 disaster shape).
+    await putSetting(t, 'remnawave.modePlacement.evade.squads', ['sq-only-copy']);
+    await expect(t.mutation(internal.seed.cleanupLegacyModeSettings, {})).rejects.toThrow(
+      /never absorbed/,
+    );
+    // Nothing deleted on the refused run.
+    expect(await t.run((ctx) => ctx.db.query('appSettings').collect())).toHaveLength(1);
+    // Once the pool exists in the new store, cleanup proceeds.
+    await t.run((ctx) =>
+      ctx.db.insert('modePlacements', {
+        modeSlug: 'freedom-ws',
+        backend: 'remnawave',
+        config: JSON.stringify({ squadUuids: ['sq-only-copy'] }),
+        updatedAt: Date.now(),
+      }),
+    );
+    expect((await t.mutation(internal.seed.cleanupLegacyModeSettings, {})).deleted).toBe(1);
+  });
+
+  test('an empty pool, or one whose mode left the catalog, does not block', async () => {
+    const t = convexTest(schema, modules);
+    await t.mutation(internal.seed.seedConnectionModes, {});
+    // Empty pool: nothing to lose.
+    await putSetting(t, 'remnawave.modePlacement.freedom-ws.squads', []);
+    // Non-empty pool for a mode the admin deleted from the catalog: dead either way.
+    await t.mutation(internal.connectionModes.removeMode, { slug: 'privacy-reality' });
+    await putSetting(t, 'remnawave.modePlacement.privacy.squads', ['sq-dead']);
+    expect((await t.mutation(internal.seed.cleanupLegacyModeSettings, {})).deleted).toBe(2);
+  });
+
+  test('re-keys censorship-matrix cells still stored under a pre-rename id', async () => {
+    const t = convexTest(schema, modules);
+    await putSetting(t, 'status.censorship', {
+      rows: [
+        { countryCode: 'CN', label: 'China', cells: { evade: 'partial', privacy: 'blocked' } },
+        // Canonical cell wins over the legacy copy.
+        { countryCode: 'IR', cells: { evade: 'blocked', 'freedom-ws': 'available' } },
+      ],
+    });
+    const out = await t.mutation(internal.seed.cleanupLegacyModeSettings, {});
+    expect(out.matrixCellsRekeyed).toBe(3);
+    const row = await t.run((ctx) =>
+      ctx.db
+        .query('appSettings')
+        .withIndex('by_key', (q) => q.eq('key', 'status.censorship'))
+        .unique(),
+    );
+    const parsed = JSON.parse(row!.value) as {
+      rows: Array<{ countryCode: string; label?: string; cells: Record<string, string> }>;
+    };
+    const cn = parsed.rows.find((r) => r.countryCode === 'CN')!;
+    expect(cn.cells).toEqual({ 'freedom-ws': 'partial', 'privacy-reality': 'blocked' });
+    expect(cn.label).toBe('China');
+    expect(parsed.rows.find((r) => r.countryCode === 'IR')!.cells).toEqual({
+      'freedom-ws': 'available',
+    });
+    // Idempotent: nothing left to re-key.
+    expect((await t.mutation(internal.seed.cleanupLegacyModeSettings, {})).matrixCellsRekeyed).toBe(
+      0,
+    );
+  });
+
+  test('a legacy spelling that IS a live catalog slug is never re-keyed', async () => {
+    const t = convexTest(schema, modules);
+    await t.mutation(internal.seed.seedConnectionModes, {});
+    // An admin re-created a mode literally slugged 'evade' and curated a cell.
+    await t.run((ctx) =>
+      ctx.db.insert('connectionModes', {
+        slug: 'evade',
+        familySlug: 'freedom',
+        deliveryStyle: 'url',
+        label: 'Evade (new)',
+        enabled: true,
+        isFamilyDefault: false,
+        backends: ['remnawave'],
+        order: 9,
+        updatedAt: Date.now(),
+      }),
+    );
+    await putSetting(t, 'status.censorship', {
+      rows: [{ countryCode: 'RU', cells: { evade: 'available' } }],
+    });
+    const out = await t.mutation(internal.seed.cleanupLegacyModeSettings, {});
+    expect(out.matrixCellsRekeyed).toBe(0);
+    const row = await t.run((ctx) =>
+      ctx.db
+        .query('appSettings')
+        .withIndex('by_key', (q) => q.eq('key', 'status.censorship'))
+        .unique(),
+    );
+    const parsed = JSON.parse(row!.value) as { rows: Array<{ cells: Record<string, string> }> };
+    expect(parsed.rows[0]!.cells).toEqual({ evade: 'available' });
   });
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -2,7 +2,6 @@
 // status, tier) must never be readable on the raw Convex channel.
 import { internalMutation, internalQuery } from './_generated/server';
 import { v } from 'convex/values';
-import { canonicalModeId } from './lib/connectionModes';
 
 export const get = internalQuery({
   args: { id: v.id('users') },
@@ -26,30 +25,6 @@ export const setConnectionMode = internalMutation({
   handler: async (ctx, { userId, modeId }) => {
     await ctx.db.patch(userId, { connectionModeId: modeId, updatedAt: Date.now() });
     return null;
-  },
-});
-
-/**
- * Lazy self-heal for a member still holding a PRE-RENAME mode id (`evade` /
- * `privacy`). Called from the account view, so an active member is migrated the
- * first time they load the page and never sees the legacy id — the bulk
- * `seed:migrateConnectionModeIds` run stays the path for everyone else.
- *
- * Same lazy-backfill shape as `supportId` / `referralCode`. Compare-and-set: the
- * patch only fires when the stored value is actually a legacy id, so the account
- * view's 60s refetch does not write on every load, and a concurrent switch that
- * already moved the member is left alone. Returns the canonical id either way.
- */
-export const canonicalizeConnectionMode = internalMutation({
-  args: { userId: v.id('users') },
-  handler: async (ctx, { userId }): Promise<string | null> => {
-    const user = await ctx.db.get(userId);
-    const stored = user?.connectionModeId ?? null;
-    if (!stored) return null;
-    const canonical = canonicalModeId(stored);
-    if (canonical === stored) return stored;
-    await ctx.db.patch(userId, { connectionModeId: canonical, updatedAt: Date.now() });
-    return canonical;
   },
 });
 

--- a/docs/convex-self-hosting.md
+++ b/docs/convex-self-hosting.md
@@ -182,39 +182,42 @@ members to carry). On a fresh backend:
    **connection-mode catalog** (the `connectionModeFamilies` / `connectionModes` /
    `modePlacements` tables — full admin CRUD at Admin → Connection modes; the
    compiled defaults also serve reads while the tables are empty, so the picker
-   is never blank pre-seed). It also converts legacy state automatically:
-   pre-refactor `connectionMode.*` / `connectionModeFamily.*` appSettings
-   overrides and `remnawave.modePlacement.*` pools fold into the new rows
-   (current keys beat legacy `evade`/`privacy` spellings; an existing row always
-   wins), the default pointer is canonicalized, pre-rename `users.connectionModeId`
-   values are rewritten (paged, run to completion inside the seed), and tiers
-   still linked by the deprecated pairwise `peerTierId` get a shared `peerGroup`.
+   is never blank pre-seed). Tiers still linked by the deprecated pairwise
+   `peerTierId` get a shared `peerGroup`.
    (The beta compose `deployer` service runs it automatically.) Adjust the
    tier limits afterward in the admin CMS (Tiers) or edit `convex/seed.ts`.
 
-   **Upgrading an existing deployment**: take a Convex snapshot export first
-   (the absorbed appSettings rows are left in place as dead data for rollback,
-   but a snapshot makes rollback trivial either way). Ship this refactor to
-   prod as its own PR/deploy and verify BEFORE any later cleanup change that
-   deletes the legacy read-fallbacks (the `LEGACY_MODE_ID_MAP` shim, the
-   appSettings pool fallback, `users.canonicalizeConnectionMode`, and the dead
-   `connectionMode.*` / `connectionModeFamily.*` / `remnawave.modePlacement.*`
-   rows) lands in a SECOND deploy, after the audit log shows no legacy traffic.
+   **Upgrading a deployment that predates the 2026-07-28 mode-catalog release**:
+   that release's `seedCutover` performed the one-time migration (appSettings
+   copy/pool fold-in, legacy `evade`/`privacy` user-id rewrite) — and the
+   CURRENT code no longer carries it. Such a deployment MUST pass through the
+   migration release first (take a Convex snapshot export before it); jumping
+   straight to post-migration code seeds the compiled defaults and leaves
+   legacy user rows unreadable. Once the migration release has run and
+   verified, the one-shot `seed:cleanupLegacyModeSettings` deletes the dead
+   appSettings rows it absorbed (`connectionMode.*` except the live
+   `connectionMode.default` pointer, `connectionModeFamily.*`,
+   `remnawave.modePlacement.*`); it refuses to run while any user still holds
+   a pre-rename mode id, so running it too early is loud, not destructive.
 
-   Two other operator-run functions exist for later (never run automatically):
+   Operator-run functions for later (never run automatically):
    `seed:refreshDefaultClients` re-syncs the recommended-client catalog after a
    code update changes `DEFAULT_CLIENTS` (upserts by name, overwrites the
    default-managed fields, preserves each row's `enabled` flag and any
-   admin-added clients), and `lifecycle:purgeInactiveFree` is the only path that
+   admin-added clients); `lifecycle:purgeInactiveFree` is the only path that
    actually removes idle free accounts the `deactivate-idle-free` cron has
-   deactivated-and-retained. On the beta stack run them through the deployer
-   container (see `docs/beta-deploy.md` §"One-off functions").
+   deactivated-and-retained; and `seed:cleanupLegacyModeSettings` is the
+   one-shot post-migration cleanup described above. On the beta stack run them
+   through the deployer container (see `docs/beta-deploy.md` §"One-off
+   functions").
 
-   After the first upgraded deploy, re-run the Ansible panel-bootstrap once so
-   it converges the squad pools through the placement route (the legacy
-   `/admin/remnawave/mode-placements` path stays a byte-compatible alias of
-   `/admin/backends/remnawave/mode-placements`), then enable `freedom-reality`
-   in **Admin → Connection modes** once its pool is bound.
+   The Ansible role's panel-bootstrap converges the squad pools through the
+   legacy `/admin/remnawave/mode-placements` path — a byte-compatible alias of
+   `/admin/backends/remnawave/mode-placements` that also still maps the role's
+   pre-rename mode ids (`evade`/`privacy`) onto the current slugs; the alias
+   (and that mapping) lives until the role migrates to the generic route.
+   Enable `freedom-reality` in **Admin → Connection modes** once its pool is
+   bound.
 
 4. **Register Outline servers** (only if using the Outline backend): admin CMS →
    **Backend servers** (the `apiUrl` secret is stored server-side, never echoed back).

--- a/docs/project-inventory.md
+++ b/docs/project-inventory.md
@@ -49,12 +49,18 @@ is per-backend (`availableBackends`; the SPA judges against the member's own bac
 declarative capability record (`convex/lib/backends/capabilities.ts`) replaced the
 `backend === 'remnawave'` branch sites; backend-id unions all derive from `BACKEND_IDS`
 (`src/shared/contracts/backendIds.ts`); tiers gained a symmetric N-ary `peerGroup`
-(`peerTierId` is a deprecated read-fallback). `seedCutover` seeds the catalog and converts
-legacy state automatically (appSettings copy/pools fold into rows, legacy `evade`/`privacy`
-user ids rewritten, peer pairs grouped); the pre-refactor appSettings rows are left dead for
-rollback and the legacy shims (`LEGACY_MODE_ID_MAP`, the appSettings pool read-fallback,
-`users.canonicalizeConnectionMode`, the Remnawave placement-route alias for the Ansible role)
-are removed in a LATER second deploy. Behavior fixes shipped with it: the geo suggestion can no
+(`peerTierId` is a deprecated read-fallback). The migration release's `seedCutover` converted
+legacy state automatically (appSettings copy/pools folded into rows, legacy `evade`/`privacy`
+user ids rewritten, peer pairs grouped). **The deploy-2 cleanup landed right after on `beta`**:
+the legacy shims (`LEGACY_MODE_ID_MAP` + read-point canonicalization, the appSettings pool
+read-fallback, `users.canonicalizeConnectionMode`, the seed absorb/rewrite steps) are GONE, and
+the one-shot `seed:cleanupLegacyModeSettings` deletes the dead appSettings rows (guarded: refuses
+while any user still holds a pre-rename id). A deployment predating the migration release must
+pass through it before taking deploy-2 code — on `main` that means TWO sequential PRs. Still
+present: the Remnawave placement-route ALIAS (which also maps the role's `evade`/`privacy`
+entry ids) — it lives until `ansible-role-freesocks` targets the generic route; the role's
+opt-in `bind_default_mode.yml` task targets the removed bulk PATCH shape and needs the same
+cross-repo pass. Behavior fixes shipped with the overhaul: the geo suggestion can no
 longer point at a disabled/unbound mode; switch-mode validates per-(mode, backend) availability;
 switch-mode on a placement-less backend is a preference no-op (no more tombstoning a working
 key); the /status matrix stopped leaking deprecated columns and the admin matrix editor stopped


### PR DESCRIPTION
## Summary

PR 2 of 2, stacked on #7 (the migration release). **Do not merge until #7 has deployed to prod and verified** — this code carries no migration, so a deployment must pass through #7's \`seedCutover\` first. When #7 merges and its branch is deleted, this PR retargets to \`main\` automatically.

- Deletes the deploy-window shims: \`LEGACY_MODE_ID_MAP\` + every read-point canonicalization, \`users.canonicalizeConnectionMode\` + its account-view lazy-heal, the appSettings pool read-fallback in \`lib/remnawavePlacement.ts\`, and the seed absorb/rewrite steps (\`seedConnectionModes\` now only inserts compiled defaults into empty tables).
- Adds the guarded one-shot \`seed:cleanupLegacyModeSettings\`: deletes the dead appSettings rows the migration absorbed (\`connectionMode.*\` except the live \`connectionMode.default\` pointer, \`connectionModeFamily.*\`, \`remnawave.modePlacement.*\`). It **refuses** while any user still holds a pre-rename mode id, so running it against an unmigrated deployment is loud, not destructive.
- The Ansible alias route stays and now owns the legacy-id mapping for the role's \`{modes:{evade,privacy}}\` PATCH bodies (the live role still sends pre-rename ids; the contract test pins the role's real body including the teardown detach). The alias + map drop in a later pass once every inventory runs role \`b082c2b\`+.

## Verification

Live on beta since 2026-07-28: deployed, then \`seed:cleanupLegacyModeSettings\` ran (\`{deleted: 21}\`, re-run \`{deleted: 0}\`). 1022 tests, typecheck/lint clean.

## Deploy notes (prod, after this merges)

1. Deploy.
2. Run the one-off cleanup through the stack's deployer container:
   \`bunx convex run seed:cleanupLegacyModeSettings '{}'\`
   Expect a small \`deleted\` count, then \`{deleted: 0}\` on a re-run.
3. Only converge Ansible inventories with role \`b082c2b\`+ against this FCP (older role checkouts keep working via the alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)