### PR TITLE
Drop the legacy Remnawave placement-route alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Highlights:
   `POST /api/v1/billing/checkout` + `GET /api/v1/billing/order/*` (self-service
   membership + donations),
   `POST /api/v1/account/gift-codes/ack` + `GET /api/v1/account/codes` (gift purchases).
-- **Admin (cookie or scope-checked token):** `GET|POST|PATCH|DELETE /api/v1/admin/{status,tiers,users,admins,tokens,audit,settings,rate-limits,membership-codes,backend-servers,billing,mirror-providers,theme,site,verification,clients,connection-modes,client-ip,status/{page,incidents},referrals/config,remnawave/{node-stats,mode-placements,logging-status,harden-logging}}/*` — every route enforces a scope on token callers (several features share the broader `admin:settings:*` / `admin:users:*` scopes rather than one scope per feature); the Ansible role's idempotent `by-slug` / `by-name` upserts live under these.
+- **Admin (cookie or scope-checked token):** `GET|POST|PATCH|DELETE /api/v1/admin/{status,tiers,users,admins,tokens,audit,settings,rate-limits,membership-codes,backend-servers,backends/{backend}/mode-placements,billing,mirror-providers,theme,site,verification,clients,connection-modes,connection-mode-families,client-ip,status/{page,incidents},referrals/config,remnawave/{node-stats,logging-status,harden-logging}}/*` — every route enforces a scope on token callers (several features share the broader `admin:settings:*` / `admin:users:*` scopes rather than one scope per feature); the Ansible role's idempotent `by-slug` / `by-name` upserts live under these.
 - **Plumbing:** `GET|POST /api/admin/auth/*` (WebAuthn passkey ceremonies + bootstrap),
   `POST /api/webhooks/billing` (generic HMAC inbound), and the processor webhooks
   `POST /api/webhooks/{nowpayments,btcpay,stripe,paypal}`.

--- a/convex/adminApi.ts
+++ b/convex/adminApi.ts
@@ -445,7 +445,7 @@ export const deleteTier = internalMutation({
  *    converge can adjust an already-seeded tier without disturbing its other
  *    entitlements.
  * Audited as `admin.tier.upsert`. (Node placement is bound separately, per
- * connection mode, via /api/v1/admin/remnawave/mode-placements — never here.)
+ * connection mode, via /api/v1/admin/backends/{backend}/mode-placements — never here.)
  */
 export const upsertTierBySlug = internalMutation({
   args: {

--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -355,18 +355,18 @@ describe('route-level scope enforcement', () => {
       subjectType: 'service',
     });
     const body = JSON.stringify({
-      modes: { evade: { squadUuids: ['e5c4de00-1111-4111-8111-cccccccccccc'] } },
+      modes: { 'freedom-ws': { squadUuids: ['e5c4de00-1111-4111-8111-cccccccccccc'] } },
     });
 
-    const bound = await t.fetch('/api/v1/admin/remnawave/mode-placements', {
+    const bound = await t.fetch('/api/v1/admin/backends/remnawave/mode-placements', {
       method: 'PATCH',
       headers: { authorization: `Bearer ${serversW}`, 'content-type': 'application/json' },
       body,
     });
     expect(bound.status).toBe(200);
 
-    // The OLD scope (settings:write) is now rejected on the pool bind.
-    const wrongScope = await t.fetch('/api/v1/admin/remnawave/mode-placements', {
+    // The OLD scope (settings:write) is rejected on the pool bind.
+    const wrongScope = await t.fetch('/api/v1/admin/backends/remnawave/mode-placements', {
       method: 'PATCH',
       headers: { authorization: `Bearer ${settingsW}`, 'content-type': 'application/json' },
       body,
@@ -1332,10 +1332,10 @@ describe('suggestedModeId respects enabled + availability', () => {
 });
 
 /**
- * The connection-mode admin surface: per-entity CRUD routes, the generic
- * per-backend placement route, and THE ANSIBLE CONTRACT — the legacy
- * /admin/remnawave/mode-placements PATCH must keep accepting its exact body
- * shape and returning its exact response shape while the role migrates.
+ * The connection-mode admin surface: per-entity CRUD routes and the generic
+ * per-backend placement route (the Ansible role's bind path; its legacy
+ * /admin/remnawave/mode-placements alias was removed 2026-07-30 after the
+ * role converged — pinned below as a 404).
  */
 describe('connection-mode admin routes', () => {
   const SQUAD = '11111111-2222-3333-4444-555555555555';
@@ -1426,67 +1426,22 @@ describe('connection-mode admin routes', () => {
     ).toBe(200);
   });
 
-  test('ANSIBLE CONTRACT: the legacy remnawave placement PATCH keeps its body + response shape, writes the NEW store', async () => {
+  test('the legacy remnawave placement alias is GONE (removed 2026-07-30, role converged)', async () => {
+    // The byte-compatible alias (with its evade/privacy id mapping) existed
+    // for ansible-role-freesocks; both stacks now converge through the
+    // generic route, so a request here must 404 — never silently rebind.
     const t = convexTest(schema, modules);
     const token = await insertToken(t, {
       scopes: ['admin:servers:write'],
       subjectType: 'service',
     });
-    // The role keys its entries by the PRE-RENAME ids (evade/privacy — see
-    // tasks/providers/fcp/bind_placements.yml); the alias route must map them
-    // onto the current slugs. Pinned with the role's real body, not the
-    // canonical spelling.
     const res = await t.fetch('/api/v1/admin/remnawave/mode-placements', {
       method: 'PATCH',
       headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
       body: JSON.stringify({ modes: { evade: { addSquadUuids: [SQUAD] } } }),
     });
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      bound: string[];
-      placements: Array<{ modeId: string; boundCount: number }>;
-    };
-    expect(body.bound).toContain('freedom-ws');
-    expect(body.placements.find((p) => p.modeId === 'freedom-ws')!.boundCount).toBe(1);
-    // The write landed in the NEW store, not appSettings.
-    const stored = await t.run(async (ctx) => ctx.db.query('modePlacements').collect());
-    expect(stored).toHaveLength(1);
-    expect(stored[0]).toMatchObject({ modeSlug: 'freedom-ws', backend: 'remnawave' });
-    const settingsPools = await t.run(async (ctx) =>
-      (await ctx.db.query('appSettings').collect()).filter((r) =>
-        r.key.startsWith('remnawave.modePlacement.'),
-      ),
-    );
-    expect(settingsPools).toHaveLength(0);
-
-    // Canonical ids pass through the alias untouched; when both spellings of
-    // one mode appear in a single body the canonical entry wins.
-    const SQUAD2 = '22222222-3333-4444-5555-666666666666';
-    const SQUAD3 = '33333333-4444-5555-6666-777777777777';
-    const mixed = await t.fetch('/api/v1/admin/remnawave/mode-placements', {
-      method: 'PATCH',
-      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-      body: JSON.stringify({
-        modes: {
-          evade: { squadUuids: [SQUAD3] },
-          'freedom-ws': { squadUuids: [SQUAD2] },
-        },
-      }),
-    });
-    expect(mixed.status).toBe(200);
-    const after = await t.run(async (ctx) => ctx.db.query('modePlacements').collect());
-    expect(after).toHaveLength(1);
-    expect(JSON.parse(after[0]!.config)).toEqual({ squadUuids: [SQUAD2] });
-
-    // The node-teardown detach path (removeSquadUuids under the legacy id).
-    const detach = await t.fetch('/api/v1/admin/remnawave/mode-placements', {
-      method: 'PATCH',
-      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-      body: JSON.stringify({ modes: { evade: { removeSquadUuids: [SQUAD2] } } }),
-    });
-    expect(detach.status).toBe(200);
-    const detached = await t.run(async (ctx) => ctx.db.query('modePlacements').collect());
-    expect(JSON.parse(detached[0]!.config)).toEqual({ squadUuids: [] });
+    expect(res.status).toBe(404);
+    expect(await t.run(async (ctx) => ctx.db.query('modePlacements').collect())).toHaveLength(0);
   });
 
   test('generic per-backend placement route: PATCH + GET summaries; placement-less backend 400s', async () => {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -2198,7 +2198,7 @@ http.route({
 // PUT /api/v1/admin/tiers/by-slug/{slug}: idempotent upsert (Ansible / IaC).
 // A distinct METHOD (PUT) from the by-id PATCH/DELETE prefix routes above, so
 // the two never collide; the slug comes from the path (authoritative). Node
-// placement is NOT bound here — that's /api/v1/admin/remnawave/mode-placements.
+// placement is NOT bound here — that's /api/v1/admin/backends/{backend}/mode-placements.
 http.route({
   pathPrefix: '/api/v1/admin/tiers/by-slug/',
   method: 'PUT',
@@ -3122,9 +3122,9 @@ http.route({
 });
 
 // --- generic per-backend placement binding ------------------------------------
-// The backend-agnostic successor of /admin/remnawave/mode-placements (which
-// stays as a byte-compatible alias for the Ansible role). Path shape:
-// /api/v1/admin/backends/{backend}/mode-placements.
+// Path shape: /api/v1/admin/backends/{backend}/mode-placements. (Succeeded the
+// Remnawave-only /admin/remnawave/mode-placements route; its byte-compatible
+// alias was removed 2026-07-30 once the Ansible role converged on this one.)
 
 function backendFromPlacementPath(req: Request): BackendId | null {
   const parts = new URL(req.url).pathname.split('/').filter(Boolean);
@@ -3282,59 +3282,10 @@ http.route({
   }),
 });
 
-// PATCH /api/v1/admin/remnawave/mode-placements: bind each mode's squad pool (the
-// nodes its keys are issued across). Write-only squad UUIDs; dual-mode (an fsv1_
-// token with admin:servers:write works — the Ansible panel-bootstrap PATCHes this
-// after it creates the per-node squads).
-//
-// PERMANENT-UNTIL-FURTHER-NOTICE ALIAS of the generic per-backend route
-// (PATCH /api/v1/admin/backends/remnawave/mode-placements, phase 3): the
-// Ansible role calls THIS path with this exact body/response shape, so it
-// keeps working byte-identically while the role migrates at leisure.
-//
-// The role also still keys its entries by the PRE-RENAME mode ids
-// (evade/privacy — tasks/providers/fcp/bind_placements.yml and the node
-// teardown detach), so this route maps them onto the current slugs before
-// delegating. The map lives HERE and only here: it is part of the alias
-// contract and is deleted together with the route once the role migrates.
-// When both spellings of a mode appear in one body, the canonical entry wins.
-const ANSIBLE_LEGACY_PLACEMENT_IDS: Readonly<Record<string, string>> = {
-  evade: 'freedom-ws',
-  privacy: 'privacy-reality',
-};
-http.route({
-  path: '/api/v1/admin/remnawave/mode-placements',
-  method: 'PATCH',
-  handler: sealed(async (ctx, req) => {
-    const admin = await resolveAdmin(ctx, req, 'admin:servers:write');
-    if (!admin) return ADMIN_UNAUTH();
-    const body = await readJson<Record<string, unknown>>(req);
-    const rawModes =
-      body && typeof body.modes === 'object' && body.modes !== null
-        ? (body.modes as Record<string, unknown>)
-        : {};
-    const modes: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(rawModes)) {
-      const canonical = ANSIBLE_LEGACY_PLACEMENT_IDS[key];
-      if (canonical) {
-        if (!(canonical in rawModes)) modes[canonical] = entry;
-      } else {
-        modes[key] = entry;
-      }
-    }
-    try {
-      return json(
-        await ctx.runMutation(internal.connectionModes.setModePlacements, {
-          backend: 'remnawave',
-          patch: { ...body, modes },
-          actorAdminId: admin.adminUserId,
-        }),
-      );
-    } catch (err) {
-      return adminError(err);
-    }
-  }),
-});
+// (The legacy PATCH /api/v1/admin/remnawave/mode-placements alias — kept while
+// ansible-role-freesocks still targeted it with pre-rename mode ids — was
+// REMOVED 2026-07-30 after both stacks converged on the role version that
+// PATCHes the generic /api/v1/admin/backends/remnawave/mode-placements route.)
 
 // GET /api/v1/admin/remnawave/logging-status: dry-run report of the Xray
 // no-client-IP-logging posture across every Remnawave config profile (read-only;

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -336,9 +336,9 @@ How a placement is chosen for Remnawave (all Remnawave-local, under
   config (Remnawave: `{"squadUuids": [...]}`). Bind it in **Admin → Remnawave**
   (one UUID per line, per mode) or via
   `PATCH /api/v1/admin/backends/remnawave/mode-placements` (scope
-  `admin:servers:write`); the legacy `PATCH /api/v1/admin/remnawave/mode-placements`
-  stays a byte-compatible ALIAS for the Ansible role's panel-bootstrap until the
-  role migrates. Per mode the patch composes three ops (applied replace → add →
+  `admin:servers:write`) — the route the Ansible role's panel-bootstrap PATCHes
+  (its legacy `/admin/remnawave/mode-placements` alias was removed 2026-07-30
+  once the role converged). Per mode the patch composes three ops (applied replace → add →
   remove): `squadUuids` (full replace; `[]` clears), `addSquadUuids` (union,
   deduped), and `removeSquadUuids` — the add/remove forms exist so a node deploy
   can append or detach just ITSELF without knowing the rest of the pool.

--- a/docs/convex-self-hosting.md
+++ b/docs/convex-self-hosting.md
@@ -211,11 +211,10 @@ members to carry). On a fresh backend:
    through the deployer container (see `docs/beta-deploy.md` §"One-off
    functions").
 
-   The Ansible role's panel-bootstrap converges the squad pools through the
-   legacy `/admin/remnawave/mode-placements` path — a byte-compatible alias of
-   `/admin/backends/remnawave/mode-placements` that also still maps the role's
-   pre-rename mode ids (`evade`/`privacy`) onto the current slugs; the alias
-   (and that mapping) lives until the role migrates to the generic route.
+   The Ansible role's panel-bootstrap converges the squad pools through
+   `PATCH /admin/backends/remnawave/mode-placements` (requires role
+   `b082c2b`+; the legacy `/admin/remnawave/mode-placements` alias and its
+   pre-rename id mapping were removed 2026-07-30 after both stacks converged).
    Enable `freedom-reality` in **Admin → Connection modes** once its pool is
    bound.
 

--- a/docs/project-inventory.md
+++ b/docs/project-inventory.md
@@ -81,10 +81,12 @@ both levels) binds a **pool of per-node squads**
 node** of that pool by node telemetry (`usersOnline` + optional realtime bandwidth, cached in
 `remnawaveNodeStats` by the healthcheck cron); the pick is persisted so tier pushes never re-home
 a live key. Remnawave specifics moved behind a namespaced admin surface — **Admin → Remnawave**
-(`PATCH /api/v1/admin/remnawave/mode-placements` [`admin:servers:write`],
-`GET /api/v1/admin/remnawave/node-stats` [`admin:servers:read`]) — while the generic mode
-catalog (labels/description/default) stays at `PATCH /api/v1/admin/connection-modes`
-(`admin:settings:write`). A one-time cutover migration copied live subs/users/settings onto
+(placement binding, now `PATCH /api/v1/admin/backends/remnawave/mode-placements`
+[`admin:servers:write`] — the original `/admin/remnawave/mode-placements` path this redesign
+introduced was removed 2026-07-30; `GET /api/v1/admin/remnawave/node-stats`
+[`admin:servers:read`]) — while the mode catalog moved to the per-entity
+`/api/v1/admin/connection-modes` CRUD routes (`admin:settings:write`; the bulk PATCH this
+paragraph originally described is gone). A one-time cutover migration copied live subs/users/settings onto
 the new fields, after which the old fields (`subscriptions.remnawaveSquadUuid`,
 `users.connectionProfileId`, `tiers.remnawaveSquadUuid`, the `remnawaveSquadStats` table) + the
 migration itself were **removed** (Phase 5b). See `docs/backends.md` § "Node placement".

--- a/docs/project-inventory.md
+++ b/docs/project-inventory.md
@@ -56,11 +56,12 @@ the legacy shims (`LEGACY_MODE_ID_MAP` + read-point canonicalization, the appSet
 read-fallback, `users.canonicalizeConnectionMode`, the seed absorb/rewrite steps) are GONE, and
 the one-shot `seed:cleanupLegacyModeSettings` deletes the dead appSettings rows (guarded: refuses
 while any user still holds a pre-rename id). A deployment predating the migration release must
-pass through it before taking deploy-2 code — on `main` that means TWO sequential PRs. Still
-present: the Remnawave placement-route ALIAS (which also maps the role's `evade`/`privacy`
-entry ids) — it lives until `ansible-role-freesocks` targets the generic route; the role's
-opt-in `bind_default_mode.yml` task targets the removed bulk PATCH shape and needs the same
-cross-repo pass. Behavior fixes shipped with the overhaul: the geo suggestion can no
+pass through it before taking deploy-2 code — on `main` that meant TWO sequential PRs (both
+deployed to prod 2026-07-30; 1478 member rows migrated, cleanup ran on both stacks).
+`ansible-role-freesocks` migrated to the generic placement route + per-slug default-mode PATCH
+and both stacks converged with it, after which the legacy Remnawave placement-route ALIAS (and
+its `evade`/`privacy` id mapping) was REMOVED (2026-07-30) — the legacy path now 404s, pinned
+by a test. Behavior fixes shipped with the overhaul: the geo suggestion can no
 longer point at a disabled/unbound mode; switch-mode validates per-(mode, backend) availability;
 switch-mode on a placement-less backend is a preference no-op (no more tombstoning a working
 key); the /status matrix stopped leaking deprecated columns and the admin matrix editor stopped
@@ -293,7 +294,7 @@ report new issues via [`SECURITY.md`](../SECURITY.md).)
 - **IaC-addressable mutations** (for the Ansible role): idempotent **`PUT …/backend-servers/by-slug/{slug}`** + **`DELETE …/by-slug/{slug}`**, **`PUT …/tiers/by-slug/{slug}`**, and **`PUT
 …/mirror-providers/by-name/{name}`**. Each is a single keep-secret-on-blank upsert; no
   client-side id resolution. Backed by `convex/adminApi.ts` / `convex/mirrorProviders.ts`.
-  Node placement is bound separately via **`PATCH …/remnawave/mode-placements`**
+  Node placement is bound separately via **`PATCH …/backends/remnawave/mode-placements`**
   (`admin:servers:write`): the role creates one squad per node and binds each connection mode's
   pool there — per mode via full-replace `squadUuids` or the append/detach forms
   `addSquadUuids`/`removeSquadUuids` (so a node deploy adds/removes just itself; UUIDs stay

--- a/src/shared/contracts/admin.ts
+++ b/src/shared/contracts/admin.ts
@@ -338,9 +338,9 @@ export const RemnawavePlacementCount = z.object({
 });
 export type RemnawavePlacementCount = z.infer<typeof RemnawavePlacementCount>;
 
-/** Response of PATCH /api/v1/admin/remnawave/mode-placements: which modes now
- *  have a pool bound + the per-mode sizes. `placements` is defaulted for
- *  rolling-deploy compat (an older backend omits it). */
+/** Response of PATCH /api/v1/admin/backends/remnawave/mode-placements: which
+ *  modes now have a pool bound + the per-mode sizes. `placements` is defaulted
+ *  for rolling-deploy compat (an older backend omits it). */
 export const RemnawavePlacementUpdateResponse = z.object({
   bound: z.array(z.string()),
   placements: z.array(RemnawavePlacementCount).optional().default([]),


### PR DESCRIPTION
## Summary

The final cleanup from the DB-driven mode-catalog overhaul. Both stacks (beta + prod) now converge through the generic \`PATCH /api/v1/admin/backends/remnawave/mode-placements\` with ansible-role-freesocks \`b082c2b\`+ (live-verified on each, 2026-07-30), so the byte-compatible legacy alias at \`/api/v1/admin/remnawave/mode-placements\` — and the \`evade\`/\`privacy\` entry-id mapping only it carried — is removed.

- The legacy path now 404s, pinned by a test: a stale role checkout fails loudly instead of silently rebinding pools.
- Scope-enforcement tests moved onto the generic route; stale comments and docs updated.

No data or schema changes; deploy whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)