### PR TITLE
docs(env): make the CHANGE_ME-is-correct warning visible at the secret lines

### DIFF
--- a/.env.convex.example
+++ b/.env.convex.example
@@ -19,7 +19,12 @@
 # CHANGE_ME for those still aborts the deploy.
 #
 # To set your own instead: generate 32-byte secrets with `openssl rand -hex 32`.
-# ACCOUNT_ID_PEPPER is SET ONCE: changing it invalidates every account number.
+# Do this BEFORE the first deploy. On a RUNNING deployment, replacing a value the
+# deployer already generated overwrites the live secret: for ACCOUNT_ID_PEPPER
+# that PERMANENTLY LOCKS OUT every existing member (their account number is the
+# only credential — there is no email reset), and for the SIGNING_KEYs it signs
+# everyone out. Verify what is live with `bunx convex env list`; a CHANGE_ME here
+# does NOT mean the deployment is unconfigured.
 # Retrieve the auto-generated ADMIN_BOOTSTRAP_SECRET (for the first admin passkey)
 # with: bunx convex env get ADMIN_BOOTSTRAP_SECRET.
 
@@ -29,6 +34,10 @@ ADMIN_SESSION_SIGNING_KEY=CHANGE_ME_hex32
 # first admin passkey (step 4) — retrieve via `bunx convex env get`.
 ADMIN_BOOTSTRAP_SECRET=CHANGE_ME_hex32
 IP_HASH_SALT=CHANGE_ME_hex32
+# SET ONCE. Leaving this as CHANGE_ME is CORRECT on a deployed stack (the
+# deployer generated a real value on the first deploy and skips this line
+# forever after). Never replace it on a running deployment: every member's
+# account number stops working, irreversibly.
 ACCOUNT_ID_PEPPER=CHANGE_ME_hex32
 
 # --- CDN-blinding (E2EE) SECRET keys ------------------------------------------

--- a/.env.convex.example
+++ b/.env.convex.example
@@ -23,15 +23,20 @@
 # deployer already generated overwrites the live secret: for ACCOUNT_ID_PEPPER
 # that PERMANENTLY LOCKS OUT every existing member (their account number is the
 # only credential — there is no email reset), and for the SIGNING_KEYs it signs
-# everyone out. Verify what is live with `bunx convex env list`; a CHANGE_ME here
-# does NOT mean the deployment is unconfigured.
-# Retrieve the auto-generated ADMIN_BOOTSTRAP_SECRET (for the first admin passkey)
-# with: bunx convex env get ADMIN_BOOTSTRAP_SECRET.
+# everyone out. A CHANGE_ME here does NOT mean the deployment is unconfigured:
+# check what is actually live with `convex env list`, which must be run THROUGH
+# THE DEPLOYER CONTAINER (the host shell has no Convex credentials, so a bare
+# `bunx convex env …` fails with "No CONVEX_DEPLOYMENT set") — copy the recipe in
+# docs/beta-deploy.md § "One-off functions".
+# The auto-generated ADMIN_BOOTSTRAP_SECRET (for the first admin passkey) is
+# printed in the deployer's log on every deploy — easiest source; otherwise read
+# it with `convex env get ADMIN_BOOTSTRAP_SECRET` via that same recipe.
 
 SESSION_SIGNING_KEY=CHANGE_ME_hex32
 ADMIN_SESSION_SIGNING_KEY=CHANGE_ME_hex32
 # Auto-generated if left as CHANGE_ME; paste it in the browser to register the
-# first admin passkey (step 4) — retrieve via `bunx convex env get`.
+# first admin passkey (step 4) — read it from the deployer's log, or via the
+# deployer-container recipe in docs/beta-deploy.md § "One-off functions".
 ADMIN_BOOTSTRAP_SECRET=CHANGE_ME_hex32
 IP_HASH_SALT=CHANGE_ME_hex32
 # SET ONCE. Leaving this as CHANGE_ME is CORRECT on a deployed stack (the


### PR DESCRIPTION
## What

Repeats the auto-generated-secrets warning **at the value lines** in `.env.convex.example`, and makes the consequence of overwriting `ACCOUNT_ID_PEPPER` concrete.

## Why

Reviewing prod tonight, seeing this in `.env.convex` reads as a live incident:

```
SESSION_SIGNING_KEY=CHANGE_ME_hex32
...
ACCOUNT_ID_PEPPER=CHANGE_ME_hex32
```

It isn't — those five names are `AUTO_GEN_SECRETS` in `docker/deploy-entrypoint.sh`, so the deployer *skips* a `CHANGE_ME` for them and generates a real value once, never regenerating. Prod was verified healthy (all five are 64-hex on the deployment).

The file header already said this. The problem is that nobody re-reads a 24-line header while eyeballing values, and the **intuitive "fix" is the catastrophic one**: filling in the placeholders and redeploying overwrites the live secrets, and a new `ACCOUNT_ID_PEPPER` permanently locks out every existing member (the account number is their only credential, `HMAC-SHA256(pepper, number)`, no email reset).

## Change

- Inline warning above `ACCOUNT_ID_PEPPER`: leaving it as `CHANGE_ME` is *correct* on a deployed stack; never replace it on a running deployment.
- Header: spells out the consequences (pepper = permanent member lockout, signing keys = everyone signed out), says to set your own *before* the first deploy, and points at `convex env list` as the way to check what is actually live.

Docs only, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)