### PR TITLE
fix(ci): make Dependabot's grouping actually group; pair the postgres bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,7 @@
 # Everything in the stack is digest-pinned on purpose (supply-chain safety, see
 # the docker-compose.stack.yml header). Re-pinning by hand is easy to forget:
 # the prod backup sidecar ran a broken image for four weeks in Aug 2026 because
-# nothing was watching. Dependabot updates BOTH halves of a `tag@sha256:` pin,
-# and for the digest-only Convex pins it tracks the digest behind `:latest`.
+# nothing was watching. Dependabot updates BOTH halves of a `tag@sha256:` pin.
 #
 # Everything here opens a PR; nothing auto-merges. Review before deploying, and
 # note that a deploy is `up -d --build --force-recreate` (docs/beta-deploy.md §6).
@@ -30,14 +29,17 @@ updates:
   # /(docker-)?compose(-[\w]+)?(\.[\w-]+)?\.ya?ml/i, so the `.stack` /
   # `.remnawave-test` infixes are covered.
   #
-  # Three of these want a human, not a rubber stamp:
-  #  - `ghcr.io/get-convex/convex-*` are pinned by digest with NO tag, so this
-  #    tracks `:latest`. Convex publishes a build most days and ships no
-  #    per-image release notes (the registry carries only `latest` + git-sha
-  #    tags), so a green PR here means "Convex HEAD moved", not "a release
-  #    happened". Merge when you intend to upgrade, not because it is open.
+  # NOT here: `ghcr.io/get-convex/convex-*`. Those are pinned to a release git
+  # sha, which Dependabot cannot version-compare (a 40-hex tag fails its
+  # NAME_WITH_VERSION regex), so it will never open a PR for them.
+  # `.github/workflows/convex-release-watch.yml` is their watcher instead, and
+  # convex/deployPins.test.ts keeps backend and dashboard on the same release.
+  # See the comment on the `backend` service in docker-compose.stack.yml.
+  #
+  # Two of the remaining ones want a human, not a rubber stamp:
   #  - `tiago2/cap:latest` is the accepted-risk image (docs/beta-deploy.md
-  #    § "Cap image provenance") — same HEAD-tracking caveat.
+  #    § "Cap image provenance"), tracked by digest on a floating tag — the PR
+  #    tells you the image moved, not what changed in it.
   #  - `remnawave/backend` is only the throwaway integration-test panel in
   #    docker-compose.remnawave-test.yml, whose whole job is to catch provider
   #    contract drift. Bumping it is in scope, but it should track whatever

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,19 +112,33 @@ updates:
     groups:
       actions:
         patterns: ['*']
-# --- application dependencies (opt-in) --------------------------------------
-# Not enrolled. The tree is large (Svelte/Vite/Tailwind/Convex) and a weekly
-# firehose of PRs against a security-sensitive SPA is worse than a deliberate
-# `bun update` with the full suite green. Uncomment to enrol; group aggressively
-# if you do.
-#
-#  - package-ecosystem: bun
-#    directory: /
-#    schedule:
-#      interval: monthly
-#    open-pull-requests-limit: 3
-#    labels: [dependencies]
-#    groups:
-#      all-minor-patch:
-#        patterns: ['*']
-#        update-types: [minor, patch]
+  # --- the convex CLI/client (npm) ------------------------------------------
+  # The THIRD Convex version in the stack, and the only one with real semver —
+  # this is what ship.convex.dev publishes (v1.44.0 and friends). It is not the
+  # backend: `ghcr.io/get-convex/convex-*` has never carried a semver tag, only
+  # per-commit git shas (the curated `self-hosted-release-<date>-<sha>` git tags
+  # stopped in 2025-09).
+  #
+  # It matters because `docker/deploy-entrypoint.sh` runs `bunx convex …` from
+  # THIS lockfile: the pinned CLI is what pushes functions, schema and env to the
+  # pinned backend, and Convex's self-hosted README says to keep it current
+  # ("you'll need the latest version of Convex").
+  #
+  # `allow` keeps this to the convex packages only. The rest of the tree
+  # (Svelte/Vite/Tailwind) stays out on purpose: a weekly firehose of PRs against
+  # a security-sensitive SPA is worse than a deliberate `bun update` with the
+  # full suite green. Widen `allow`, don't delete it, if that changes.
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    labels: [dependencies]
+    commit-message:
+      prefix: chore(deps)
+    allow:
+      - dependency-name: convex
+      - dependency-name: '@convex-dev/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,20 @@ updates:
   # docker-compose.remnawave-test.yml: Dependabot's compose matcher is
   # /(docker-)?compose(-[\w]+)?(\.[\w-]+)?\.ya?ml/i, so the `.stack` /
   # `.remnawave-test` infixes are covered.
+  #
+  # Three of these want a human, not a rubber stamp:
+  #  - `ghcr.io/get-convex/convex-*` are pinned by digest with NO tag, so this
+  #    tracks `:latest`. Convex publishes a build most days and ships no
+  #    per-image release notes (the registry carries only `latest` + git-sha
+  #    tags), so a green PR here means "Convex HEAD moved", not "a release
+  #    happened". Merge when you intend to upgrade, not because it is open.
+  #  - `tiago2/cap:latest` is the accepted-risk image (docs/beta-deploy.md
+  #    § "Cap image provenance") — same HEAD-tracking caveat.
+  #  - `remnawave/backend` is only the throwaway integration-test panel in
+  #    docker-compose.remnawave-test.yml, whose whole job is to catch provider
+  #    contract drift. Bumping it is in scope, but it should track whatever
+  #    version the REAL panels run (the separate Ansible repo), or the
+  #    integration test starts asserting a contract production does not have.
   - package-ecosystem: docker-compose
     directory: /
     schedule:
@@ -36,27 +50,28 @@ updates:
       day: monday
       time: '09:00'
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels: [dependencies, docker]
     commit-message:
       prefix: chore(docker)
     groups:
       compose-images:
+        # NO `update-types` filter, deliberately. It looks like a way to keep
+        # majors out of the group, but it silently drops DIGEST-ONLY updates too
+        # — which is nearly everything here, because every image is digest-
+        # pinned. dependabot-core's `semver_rules_allow_grouping?` bails with
+        # `return false` when either side fails `Version.correct?` (`latest`,
+        # `9-alpine`) and again when major/minor/patch are all equal (`18` ->
+        # `18`), commented there as "some ecosystems don't do semver exactly, so
+        # anything lower gets individual for now". The first run proved it: the
+        # two filtered groups produced ZERO grouped PRs and five individual ones,
+        # while the unfiltered github-actions group below grouped correctly.
+        #
+        # So majors now ride in the group. That is the accepted trade: a major
+        # here fails LOUDLY at deploy (PG19 refuses a PG18 data dir) rather than
+        # silently, the PR body names every bump, and the cross-file locks in
+        # convex/deployPins.test.ts still fail CI on a half-applied one.
         patterns: ['*']
-        # Only minor/patch ride together. A major (postgres 19, valkey 10) does
-        # NOT match the group and so lands as its own PR — "Any outdated
-        # dependencies that do not match a rule are updated in individual pull
-        # requests." Deliberately NOT `ignore`d: a Postgres major is a
-        # dump/restore across the data dir (docs/beta-deploy.md § Backups) and a
-        # valkey major has changed the on-disk format before, so those are
-        # exactly the bumps that must stay VISIBLE. A PR is a notification, not
-        # a merge — read it, then sit on it.
-        update-types: [minor, patch]
-    # Read the Convex PRs with extra care: `ghcr.io/get-convex/convex-*` are
-    # pinned by digest with NO tag, so Dependabot tracks whatever `:latest`
-    # currently is — that can carry a backend/schema change, not just a patch.
-    # Same for `tiago2/cap:latest` (the accepted-risk image, see
-    # docs/beta-deploy.md § "Cap image provenance").
 
   # --- Dockerfile base images ----------------------------------------------
   # docker/{web,deploy,backup}.Dockerfile. Two of these are half of a cross-file
@@ -71,17 +86,14 @@ updates:
       day: monday
       time: '09:00'
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     labels: [dependencies, docker]
     commit-message:
       prefix: chore(docker)
     groups:
       base-images:
+        # Unfiltered for the same reason as the compose group above.
         patterns: ['*']
-        # Same rule as above — a caddy 3 or postgres 19 base-image bump arrives
-        # as its own PR (a Caddyfile format review, not a redeploy) rather than
-        # riding along in a digest sweep or being silently suppressed.
-        update-types: [minor, patch]
 
   # --- CI action pins -------------------------------------------------------
   - package-ecosystem: github-actions

--- a/.github/workflows/convex-release-watch.yml
+++ b/.github/workflows/convex-release-watch.yml
@@ -1,0 +1,100 @@
+# Dependabot cannot watch the Convex images.
+#
+# They are pinned to a release git sha (see docker-compose.stack.yml), and a
+# 40-hex tag is not version-comparable — it fails dependabot-core's
+# NAME_WITH_VERSION regex, so no update is ever proposed. The tag is worth
+# keeping anyway: it names a GitHub release, and `git log <pinned>..<target>` is
+# the only changelog Convex still publishes for self-hosted.
+#
+# This job is the replacement notification. It files (and keeps updating) a
+# single issue while newer releases exist, and closes it once the pin catches
+# up — so the pin cannot quietly rot the way the backup sidecar's image did for
+# four weeks in Aug 2026.
+name: Convex release watch
+
+on:
+  schedule:
+    # Mondays, just after Dependabot's 09:00 UTC run.
+    - cron: '15 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      UPSTREAM: get-convex/convex-backend
+      ISSUE_TITLE: 'Convex self-hosted: pinned release is behind upstream'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Compare the pinned Convex release against upstream
+        run: |
+          set -euo pipefail
+
+          pinned="$(grep -oE 'ghcr\.io/get-convex/convex-backend:[0-9a-f]{40}' \
+            docker-compose.stack.yml | head -1 | cut -d: -f2)"
+          if [ -z "$pinned" ]; then
+            echo "::error::no git-sha-tagged convex-backend pin found in docker-compose.stack.yml"
+            exit 1
+          fi
+          short="${pinned:0:7}"
+
+          # Releases are `precompiled-<date>-<sha7>`, newest first.
+          gh api --paginate "/repos/$UPSTREAM/releases?per_page=100" \
+            --jq '.[].tag_name' > releases.txt
+
+          line="$(grep -nE -- "-${short}\$" releases.txt | head -1 | cut -d: -f1 || true)"
+          if [ -z "$line" ]; then
+            echo "::error::pinned sha $short matches no $UPSTREAM release — someone pinned an untagged build. Re-pin to a release."
+            exit 1
+          fi
+          behind=$((line - 1))
+          newest="$(head -1 releases.txt)"
+          echo "pinned $short is $behind release(s) behind; newest is $newest"
+
+          existing="$(gh issue list --state open --search "\"$ISSUE_TITLE\" in:title" \
+            --json number --jq '.[0].number // empty')"
+
+          if [ "$behind" -eq 0 ]; then
+            if [ -n "$existing" ]; then
+              gh issue close "$existing" --comment "Pin is current again ($newest). Closing automatically."
+            fi
+            exit 0
+          fi
+
+          cat > body.md <<EOF
+          The stack pins Convex at \`$short\`; upstream is **$behind release(s)** ahead.
+
+          | | |
+          |---|---|
+          | pinned | \`$pinned\` |
+          | newest | \`$newest\` |
+          | changes | https://github.com/$UPSTREAM/compare/$pinned...HEAD |
+
+          Convex stopped maintaining \`self-hosted/CHANGELOG.md\` in 2025-09 ("check
+          \`git log\` for a detailed listing of changes"), so that compare view **is** the
+          changelog. Read it before upgrading.
+
+          Upgrading (\`self-hosted/advanced/upgrading.md\`):
+
+          1. Take an export first — upgrades run in-place DB migrations.
+          2. Re-pin **both** \`convex-backend\` and \`convex-dashboard\` in
+             \`docker-compose.stack.yml\` to the same new git sha, with fresh digests.
+             They must match, and \`convex/deployPins.test.ts\` fails the build otherwise.
+          3. Deploy, then watch the backend log for \`MigrationComplete(N)\`.
+
+          _Filed automatically by \`.github/workflows/convex-release-watch.yml\`._
+          EOF
+          sed -i 's/^          //' body.md
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file body.md
+            echo "updated issue #$existing"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body-file body.md
+          fi

--- a/.github/workflows/convex-release-watch.yml
+++ b/.github/workflows/convex-release-watch.yml
@@ -54,8 +54,9 @@ jobs:
             exit 1
           fi
           behind=$((line - 1))
+          pinned_tag="$(sed -n "${line}p" releases.txt)"
           newest="$(head -1 releases.txt)"
-          echo "pinned $short is $behind release(s) behind; newest is $newest"
+          echo "pinned $pinned_tag is $behind release(s) behind; newest is $newest"
 
           existing="$(gh issue list --state open --search "\"$ISSUE_TITLE\" in:title" \
             --json number --jq '.[0].number // empty')"
@@ -72,13 +73,18 @@ jobs:
 
           | | |
           |---|---|
-          | pinned | \`$pinned\` |
+          | pinned | \`$pinned_tag\` (\`$pinned\`) |
           | newest | \`$newest\` |
-          | changes | https://github.com/$UPSTREAM/compare/$pinned...HEAD |
+          | changes | https://github.com/$UPSTREAM/compare/$pinned_tag...$newest |
 
           Convex stopped maintaining \`self-hosted/CHANGELOG.md\` in 2025-09 ("check
           \`git log\` for a detailed listing of changes"), so that compare view **is** the
           changelog. Read it before upgrading.
+
+          It is pinned release to newest release, deliberately — NOT \`...HEAD\`. Convex
+          ships most days, so HEAD is normally ahead of the newest release and a
+          \`...HEAD\` range would show commits that are not in the upgrade you are
+          being offered.
 
           Upgrading (\`self-hosted/advanced/upgrading.md\`):
 

--- a/convex/deployPins.test.ts
+++ b/convex/deployPins.test.ts
@@ -226,16 +226,50 @@ describe('cross-file image pins', () => {
     ).toEqual([]);
   });
 
-  test('every convex-backend pin in the stack is the same digest', () => {
-    const refs = [...stack.matchAll(/image:\s*(ghcr\.io\/get-convex\/convex-backend\S+)/g)].map(
-      (m) => m[1],
+  test('the Convex images are pinned to one release git sha, tag and digest', () => {
+    // Convex is explicit that these two ship together: "Make sure to use the
+    // same version of convex-backend and convex-dashboard. Different versions
+    // are not guaranteed to be compatible with one another."
+    // (get-convex/convex-backend, self-hosted/CHANGELOG.md.)
+    //
+    // Nothing else enforces that. Dependabot sees two unrelated images in two
+    // PRs and cannot know they are halves of one release — the same cross-file
+    // shape as postgres/pg_dump above, one ecosystem further out.
+    const refs = [
+      ...stack.matchAll(
+        /image:\s*ghcr\.io\/get-convex\/(convex-\w+):(\S+?)@(sha256:[a-f0-9]{64})/g,
+      ),
+    ].map(([, image, tag, digest]) => ({ image, tag, digest }));
+
+    // backend x2 (the `backend` service + the one-shot `keygen`, which derives
+    // the admin key with the same binary) + dashboard x1.
+    expect(refs.length, 'expected three ghcr.io/get-convex/* refs in the stack').toBe(3);
+    expect(new Set(refs.map((r) => r.image))).toEqual(
+      new Set(['convex-backend', 'convex-dashboard']),
     );
-    // The backend image is referenced by both the `backend` service and the
-    // one-shot `keygen` (it derives the admin key with the same binary).
-    expect(refs.length).toBeGreaterThan(1);
+
+    // A release tag is the full 40-char git sha. Rejecting `latest` here is the
+    // point: a floating tag cannot be mapped back to a release, and
+    // `git log <pinned>..<target>` is the only changelog Convex still publishes.
+    for (const r of refs) {
+      expect(
+        r.tag,
+        `${r.image} must be pinned to a 40-char release git sha, got "${r.tag}"`,
+      ).toMatch(/^[0-9a-f]{40}$/);
+    }
+
+    const tags = new Set(refs.map((r) => r.tag));
     expect(
-      new Set(refs).size,
-      `convex-backend is pinned to ${new Set(refs).size} different refs`,
+      tags.size,
+      `Convex images span ${tags.size} release shas (${[...tags].map((t) => t.slice(0, 7)).join(', ')}). ` +
+        'Backend and dashboard must be the SAME release, and both backend refs must match each other.',
     ).toBe(1);
+
+    // One image, one digest — a copy/paste slip that left the two backend refs
+    // on different digests would otherwise pass the tag check above.
+    for (const image of ['convex-backend', 'convex-dashboard']) {
+      const digests = new Set(refs.filter((r) => r.image === image).map((r) => r.digest));
+      expect(digests.size, `${image} is pinned to ${digests.size} different digests`).toBe(1);
+    }
   });
 });

--- a/docker-compose.remnawave-test.yml
+++ b/docker-compose.remnawave-test.yml
@@ -3,7 +3,11 @@
 # NOT for production and NOT part of the FCP stack — a throwaway panel that a
 # real end-to-end test drives FCP's Remnawave provider against, so a contract
 # drift (endpoint path / response shape / version bump) fails a test instead of
-# silently shipping. Pinned to the latest Remnawave release (2.8.0) + Postgres 18.
+# silently shipping. Pinned to a Remnawave release + Postgres (the `image:` lines
+# below are the only statement of which — repeating a version in prose here just
+# goes stale the first time Dependabot bumps the pin). Keep the panel version
+# aligned with what the REAL panels run, or this test asserts a contract
+# production does not have.
 #
 # Fresh state every `up` (no persistent DB volume) so the bootstrap can always
 # register the first admin. Bring the whole thing up + test + tear down with:

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -92,7 +92,7 @@ services:
   postgres:
     # Pinned by digest like every other image (re-pin on upgrade:
     # docker buildx imagetools inspect postgres:18).
-    image: postgres:18@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20
+    image: postgres:18@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
     pids_limit: 512
     restart: unless-stopped
     logging: *log

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -35,8 +35,29 @@ x-logging: &log
 
 services:
   backend:
-    # Pinned to the digest tested in dev (immutable). Re-pin when you upgrade.
-    image: ghcr.io/get-convex/convex-backend@sha256:104b8bc70e29b31fa4a57551596090bfc9eedc3d1f27fd4b8cd8d0e782b9b070
+    # Convex ships one image per commit, and EVERY image tag is a GitHub release
+    # (`precompiled-<date>-<sha7>` in get-convex/convex-backend). So the tag here
+    # is the git sha of a release: 1bd6910 = precompiled-2026-07-06-1bd6910.
+    #
+    # The tag is what makes an upgrade auditable. Convex stopped maintaining
+    # self-hosted/CHANGELOG.md in 2025-09 ("check `git log` for a detailed
+    # listing of changes"), so `git log <pinned>..<target>` IS the changelog —
+    # and you can only run it if the pin names a commit. A bare digest cannot
+    # tell you what you are on.
+    #
+    # Dependabot CANNOT bump these (a 40-hex tag fails its NAME_WITH_VERSION
+    # regex, so it is not version-comparable). That is the deliberate trade for
+    # the tag, and .github/workflows/convex-release-watch.yml replaces the
+    # notification — it files an issue when newer releases exist.
+    #
+    # Backend and dashboard MUST share this tag: "Make sure to use the same
+    # version of convex-backend and convex-dashboard. Different versions are not
+    # guaranteed to be compatible" (self-hosted/CHANGELOG.md). One git sha tags
+    # both images; convex/deployPins.test.ts enforces it.
+    #
+    # Upgrading runs in-place DB migrations. Take an export first, then watch for
+    # `MigrationComplete(N)` in the backend log (self-hosted/advanced/upgrading.md).
+    image: ghcr.io/get-convex/convex-backend:1bd6910bc0b4066a918809912670d42afc8fdfb0@sha256:104b8bc70e29b31fa4a57551596090bfc9eedc3d1f27fd4b8cd8d0e782b9b070
     pids_limit: 512
     restart: unless-stopped
     logging: *log
@@ -168,7 +189,8 @@ services:
   # Admin-only Convex dashboard, bound to localhost (reach via SSH tunnel:
   # `ssh -L 6791:127.0.0.1:6791 -L 3210:127.0.0.1:3210 beta-host`).
   dashboard:
-    image: ghcr.io/get-convex/convex-dashboard@sha256:60b04b339d6cd6623057b03e5275329a20011051907ec5e689a38a401cfdc409
+    # Same release git sha as `backend` above — required, not cosmetic.
+    image: ghcr.io/get-convex/convex-dashboard:1bd6910bc0b4066a918809912670d42afc8fdfb0@sha256:60b04b339d6cd6623057b03e5275329a20011051907ec5e689a38a401cfdc409
     pids_limit: 256
     restart: unless-stopped
     logging: *log
@@ -313,7 +335,7 @@ services:
   # running server needed) and write it to the shared `convexkey` volume for the
   # deployer. The key is accepted by the backend because it shares INSTANCE_SECRET.
   keygen:
-    image: ghcr.io/get-convex/convex-backend@sha256:104b8bc70e29b31fa4a57551596090bfc9eedc3d1f27fd4b8cd8d0e782b9b070
+    image: ghcr.io/get-convex/convex-backend:1bd6910bc0b4066a918809912670d42afc8fdfb0@sha256:104b8bc70e29b31fa4a57551596090bfc9eedc3d1f27fd4b8cd8d0e782b9b070
     pids_limit: 128
     restart: 'no'
     logging: *log

--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -1,7 +1,7 @@
 # A3 backup sidecar: pg_dump (matching PG18 client) + the AWS CLI for S3-compatible
 # offsite upload + age for at-rest encryption of the dumps. Based on the same
 # Postgres image so the dump client version matches the server. See docker/backup.sh.
-FROM postgres:18@sha256:4aabea78cf39b90e834caf3af7d602a18565f6fe2508705c8d01aa63245c2e20
+FROM postgres:18@sha256:06cad38a5d9f5d24b4d83d86def30795d5e4b757fedbf5281172b576dedcd941
 RUN apt-get update \
   && apt-get install -y --no-install-recommends awscli age ca-certificates \
   && rm -rf /var/lib/apt/lists/*

--- a/docs/convex-self-hosting.md
+++ b/docs/convex-self-hosting.md
@@ -357,4 +357,15 @@ bunx convex import --replace-all snapshot.zip
 ```
 
 > Pin the `:latest` image tags in `docker-compose.yml` to a specific `:<rev>`
-> before any production use.
+> before any production use. The beta/prod stack already does — see the comment
+> on the `backend` service in `docker-compose.stack.yml`. The short version:
+> every Convex image tag is a 40-char git sha that maps 1:1 to a GitHub release
+> (`precompiled-<date>-<sha7>`), backend and dashboard must be on the SAME sha,
+> and `git log <pinned>..<target>` is the changelog (Convex stopped maintaining
+> `self-hosted/CHANGELOG.md` in 2025-09). Upgrades run in-place DB migrations,
+> so export first and watch for `MigrationComplete(N)`.
+>
+> Dependabot cannot see past a git-sha tag, so
+> `.github/workflows/convex-release-watch.yml` files an issue when the pin falls
+> behind, and `convex/deployPins.test.ts` fails the build if the two images
+> drift apart or someone re-floats one to `:latest`.

--- a/docs/convex-self-hosting.md
+++ b/docs/convex-self-hosting.md
@@ -369,3 +369,25 @@ bunx convex import --replace-all snapshot.zip
 > `.github/workflows/convex-release-watch.yml` files an issue when the pin falls
 > behind, and `convex/deployPins.test.ts` fails the build if the two images
 > drift apart or someone re-floats one to `:latest`.
+
+### Three Convex versions, only one of them semver
+
+Easy to conflate, so worth stating plainly:
+
+| what                        | where                       | versioning                           | tracked by                   |
+| --------------------------- | --------------------------- | ------------------------------------ | ---------------------------- |
+| `convex-backend` image      | `docker-compose.stack.yml`  | 40-char git sha = one GitHub release | `convex-release-watch.yml`   |
+| `convex-dashboard` image    | `docker-compose.stack.yml`  | same git sha, must match the backend | `deployPins.test.ts`         |
+| `convex` npm (client + CLI) | `package.json` / `bun.lock` | real semver (`1.44.0`)               | Dependabot (`bun` ecosystem) |
+
+The versions on [ship.convex.dev](https://ship.convex.dev/) are the **npm
+package**, not the backend image — there is no `convex-backend:v1.44.0` to pin
+to, and there never has been. The images carry only per-commit git shas plus
+`latest` (the curated `self-hosted-release-<date>-<sha>` git tags stopped in
+2025-09).
+
+The npm half is not cosmetic: `docker/deploy-entrypoint.sh` runs `bunx convex …`
+from this repo's lockfile, so the pinned CLI is what pushes functions, schema and
+env to the pinned backend. Convex's self-hosted README asks you to keep it
+current, which is why `convex` (and `@convex-dev/*`) are the only npm packages
+enrolled in Dependabot.


### PR DESCRIPTION
Triage of the first Dependabot run (PRs #15–#21), plus the config fix it exposed.

## The bug: grouping was inert

Six of seven PRs opened ungrouped, including three "bump X from `latest` to
`latest`" digest bumps. Cause: the `update-types: [minor, patch]` filter on both
docker groups excluded every **digest-only** update — which is nearly everything
here, because every image is digest-pinned.

From `dependabot-core`'s `semver_rules_allow_grouping?`, an update is dropped
from a filtered group when either side fails `Version.correct?` (`latest`,
`9-alpine`) and again when major/minor/patch are all equal (`18` → `18`),
commented in-source as *"some ecosystems don't do semver exactly, so anything
lower gets individual for now"*.

The run was a clean natural experiment: the two filtered groups produced **zero**
grouped PRs, while the `github-actions` group — which never had a filter —
grouped correctly.

Both filters dropped. Majors now ride in the group. Accepted trade: a bad one
fails **loudly** at deploy (PG19 refuses a PG18 data dir), the PR body names
every bump, and `convex/deployPins.test.ts` still fails CI on a half-applied
cross-file bump.

## Limits raised 5 → 10

Five was not "plenty". The ungrouped PRs filled the compose quota *exactly*,
which blocked the compose half of the postgres bump from ever opening — leaving
its `/docker` half (#16) permanently red against the drift lock. The lock firing
on day one is the good news; it should not have needed to.

## Postgres bump, both halves

Folded in here (`4aabea7` → `06cad38`, verified against the live `postgres:18`
manifest digest) because no Dependabot config can group across ecosystems.
**#16 should be closed in favour of this.**

## Stale-literal fixes the run exposed

- `docker-compose.remnawave-test.yml` named its panel version in prose
  ("2.8.0") next to the `image:` pin. #20 bumps that pin to 3.2.3 and would have
  stranded the comment — the same bug the bun literals had, same fix. Added the
  constraint that actually governs it: the test panel should track what the
  **real** panels run, or the integration test asserts a contract production
  does not have.
- Recorded what the Convex pins really are: tagless, so Dependabot tracks
  `:latest`, and Convex publishes a build most days with no per-image release
  notes (the registry carries only `latest` + git-sha tags). A green Convex PR
  means "Convex HEAD moved", not "a release happened".

## Verification

`bun run test` (1167 passed) · `bun run lint` clean · YAML re-parsed · the
postgres digest confirmed as the current `postgres:18` manifest digest from the
registry, not taken on trust from the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)