### PR TITLE
fix(e2ee): a stale key response is not tampering, and stop freezing the attestation verdict

### DIFF
--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -564,11 +564,53 @@ describe('cache-control defaults', () => {
     expect(res.headers.get('cache-control')).toBe('no-store');
   });
 
-  test('the e2ee keys route keeps its public, max-age=60 override', async () => {
+  // A cache that outlives the epoch it holds hands clients an EXPIRED key, which
+  // the client cannot distinguish from a tampered one (it fired the loud
+  // "couldn't verify the encryption key" banner), so max-age is clamped to the
+  // remaining validity and a rotation gap is never cached.
+  test('the e2ee keys route caps max-age at the epoch validity', async () => {
+    const t = convexTest(schema, modules);
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert('keyEpochs', {
+        kid: 'kid-cache-cap',
+        publicKey: 'pk',
+        seed: 'seed',
+        manifestSig: 'sig',
+        notBefore: now - 1_000,
+        notAfter: now + 20_000, // 20s left: shorter than the 60s ceiling
+      });
+    });
+    const res = await t.fetch('/api/v1/e2ee/keys');
+    expect(res.status).toBe(200);
+    const maxAge = Number(/max-age=(\d+)/.exec(res.headers.get('cache-control') ?? '')?.[1]);
+    expect(maxAge).toBeGreaterThan(0);
+    expect(maxAge).toBeLessThanOrEqual(20);
+  });
+
+  test('the e2ee keys route keeps public, max-age=60 for a long-lived epoch', async () => {
+    const t = convexTest(schema, modules);
+    const now = Date.now();
+    await t.run(async (ctx) => {
+      await ctx.db.insert('keyEpochs', {
+        kid: 'kid-cache-full',
+        publicKey: 'pk',
+        seed: 'seed',
+        manifestSig: 'sig',
+        notBefore: now - 1_000,
+        notAfter: now + 30 * 60_000,
+      });
+    });
+    const res = await t.fetch('/api/v1/e2ee/keys');
+    expect(res.headers.get('cache-control')).toBe('public, max-age=60');
+  });
+
+  test('a rotation gap (no live epoch) is not cached at all', async () => {
     const t = convexTest(schema, modules);
     const res = await t.fetch('/api/v1/e2ee/keys');
     expect(res.status).toBe(200);
-    expect(res.headers.get('cache-control')).toBe('public, max-age=60');
+    expect(await res.json()).toMatchObject({ epoch: null });
+    expect(res.headers.get('cache-control')).toBe('no-store');
   });
 });
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -490,10 +490,24 @@ http.route({
           : null,
       },
       200,
-      { 'cache-control': 'public, max-age=60' },
+      // Cache for at most 60s, and NEVER past the epoch's own validity: a cache
+      // (browser HTTP cache, Caddy, a CDN) that outlives the key hands clients an
+      // EXPIRED epoch, which the client cannot tell apart from a tampered one and
+      // used to surface as the loud "couldn't verify the encryption key" banner.
+      // A rotation gap (epoch null) is not cached at all, so it clears the moment
+      // the rotate cron catches up.
+      { 'cache-control': epochCacheControl(epoch?.notAfter) },
     );
   }),
 });
+
+/** max-age for the key endpoint: 60s, clamped to the epoch's remaining validity. */
+function epochCacheControl(notAfter: number | undefined): string {
+  if (!notAfter) return 'no-store';
+  const remainingS = Math.floor((notAfter - Date.now()) / 1000);
+  const maxAge = Math.max(0, Math.min(60, remainingS));
+  return maxAge > 0 ? `public, max-age=${maxAge}` : 'no-store';
+}
 
 // --- account creation -------------------------------------------------------
 // Anonymous sign-up: Cap captcha -> mint a user + account number + member session.

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -492,10 +492,11 @@ http.route({
       200,
       // Cache for at most 60s, and NEVER past the epoch's own validity: a cache
       // (browser HTTP cache, Caddy, a CDN) that outlives the key hands clients an
-      // EXPIRED epoch, which the client cannot tell apart from a tampered one and
-      // used to surface as the loud "couldn't verify the encryption key" banner.
-      // A rotation gap (epoch null) is not cached at all, so it clears the moment
-      // the rotate cron catches up.
+      // EXPIRED epoch, which the client cannot tell apart from a tampered one.
+      // Rotation every 10 min against a 30-min validity means the served epoch
+      // normally has >=20 min left, so this clamp only ever bites if that ratio
+      // changes -- it is the guarantee, not a hot path. A rotation gap (epoch null)
+      // is not cached at all, so it clears the moment the rotate cron catches up.
       { 'cache-control': epochCacheControl(epoch?.notAfter) },
     );
   }),

--- a/docs/oob-verification.md
+++ b/docs/oob-verification.md
@@ -91,6 +91,36 @@ _convenience_, not the trust root: a tampered page could lie about its own statu
 the guarantee still comes from comparing through a channel the CDN doesn't control —
 the DNS lookup you run yourself, the signed release, or the `.onion` mirror.
 
+### What the live attestation check reports
+
+`/api/v1/e2ee/keys` publishes the current manifest-signed **epoch key** (rotated every
+10 minutes, valid 30). The panel verifies that signature in the browser against the
+baked manifest public key, and the verdict is deliberately split by _which_ check
+failed, because only some failures mean someone swapped a key:
+
+| Verdict       | Condition                                                                                  | Surface                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `active`      | signature verifies, unexpired, not revoked                                                 | green badge                                                                                     |
+| `warn`        | the endpoint answered and the key **fails signature verification**, or its kid is revoked  | green badge turns amber **and** the loud full-width bar ("don't enter your account number yet") |
+| `stale`       | the endpoint answered but has no live epoch: none published, or the one served had expired | panel detail only                                                                               |
+| `unreachable` | the endpoint could not be reached                                                          | panel detail only                                                                               |
+
+`stale` and `unreachable` are quiet on purpose. In both the client keeps sealing to the
+manifest-**pinned static key** baked into the bundle, so nothing is sent unprotected and
+neither state is evidence of tampering: they mean epoch rotation is behind (check the
+`epoch-key-rotate` heartbeat and the `e2ee.epoch_gap` audit action) or that a cache
+handed the client an old response. Escalating them to the loud bar was a real bug — it
+fired at users over a wedged cron and taught them to dismiss the one alarm that matters.
+Neither state hands an attacker anything new either: a CDN that wants the static-key
+fallback can already force it by simply blocking the endpoint (`unreachable`).
+
+Because an expired epoch is indistinguishable from a tampered one at the crypto layer,
+both ends refuse to let a cache create that state: the client fetches the key endpoint
+with `cache: 'no-store'`, and the server clamps the response `max-age` to the epoch's
+own remaining validity (and sends `no-store` during a rotation gap). The client also
+re-attests a visible tab every 5 minutes and on tab refocus, so a long-lived tab's
+verdict is current rather than frozen at page load.
+
 ## Reproducible build
 
 The build is deterministic given a pinned toolchain. `scripts/verify-reproducible.sh`

--- a/docs/oob-verification.md
+++ b/docs/oob-verification.md
@@ -114,12 +114,25 @@ fired at users over a wedged cron and taught them to dismiss the one alarm that 
 Neither state hands an attacker anything new either: a CDN that wants the static-key
 fallback can already force it by simply blocking the endpoint (`unreachable`).
 
+`warn`, by contrast, is **sticky**: once a swapped or revoked key has been seen, only a
+later poll that positively attests clears it. Otherwise re-attesting would hand a caught
+CDN an off switch, since blocking the next request (`unreachable`) or stripping the epoch
+(`stale`) would clear the banner. Inconclusive is not exculpatory.
+
 Because an expired epoch is indistinguishable from a tampered one at the crypto layer,
 both ends refuse to let a cache create that state: the client fetches the key endpoint
-with `cache: 'no-store'`, and the server clamps the response `max-age` to the epoch's
-own remaining validity (and sends `no-store` during a rotation gap). The client also
-re-attests a visible tab every 5 minutes and on tab refocus, so a long-lived tab's
-verdict is current rather than frozen at page load.
+with `cache: 'no-cache'` (never use a cached body without revalidating at the origin,
+while still letting caches be populated and answer with a 304), and the server clamps the
+response `max-age` to the epoch's own remaining validity, sending `no-store` during a
+rotation gap. The clamp is a guarantee rather than a hot path: rotation every 10 minutes
+against a 30-minute validity means the epoch on the wire normally has 20+ minutes left,
+so a conformant 60-second cache could not serve an expired one anyway.
+
+The client also re-attests every 5 minutes and on refocus or regained connectivity
+(throttled to one check per minute), so a long-lived tab's verdict is current rather than
+frozen at page load, and opening the verify panel forces a fresh check. The interval is
+deliberately not gated on `document.visibilityState`, because some embedded webviews
+report a displayed page as hidden forever.
 
 ## Reproducible build
 

--- a/docs/oob-verification.md
+++ b/docs/oob-verification.md
@@ -120,13 +120,18 @@ CDN an off switch, since blocking the next request (`unreachable`) or stripping 
 (`stale`) would clear the banner. Inconclusive is not exculpatory.
 
 Because an expired epoch is indistinguishable from a tampered one at the crypto layer,
-both ends refuse to let a cache create that state: the client fetches the key endpoint
-with `cache: 'no-cache'` (never use a cached body without revalidating at the origin,
-while still letting caches be populated and answer with a 304), and the server clamps the
-response `max-age` to the epoch's own remaining validity, sending `no-store` during a
-rotation gap. The clamp is a guarantee rather than a hot path: rotation every 10 minutes
-against a 30-minute validity means the epoch on the wire normally has 20+ minutes left,
-so a conformant 60-second cache could not serve an expired one anyway.
+the **server** is what keeps a cache from creating that state: the key endpoint clamps its
+response `max-age` to the epoch's own remaining validity, and sends `no-store` during a
+rotation gap. That clamp is load-bearing — raising `max-age` past the epoch validity would
+reintroduce the bug — and it is why the client can then read the endpoint under normal
+cache rules.
+
+The client deliberately does **not** force revalidation. The fetch-spec cache modes
+(`no-store`, `no-cache`) send `max-age=0`, which punches every request past the CDN to the
+origin, where the per-IP `e2ee.keys.fetch` policy lives; and a per-browser cache saves
+nothing for many distinct clients sharing one carrier-grade NAT, which only the shared CDN
+cache can absorb. Bypassing it would trade a bounded, now-quiet staleness for 429s and a
+silent static-key fallback precisely where censorship makes NAT sharing the norm.
 
 The client also re-attests every 5 minutes and on refocus or regained connectivity
 (throttled to one check per minute), so a long-lived tab's verdict is current rather than

--- a/docs/threat-model-cdn-blinding.md
+++ b/docs/threat-model-cdn-blinding.md
@@ -179,7 +179,12 @@ remove POP_REQUIRED` where the CLI is configured). Takes effect on the next requ
   identical output. The real active-CDN defense (a store-delivered verifier) is Phase 4. An in-app
   **E2EE banner + "Verify connection" panel** surface the active status + the same fingerprints (plus a
   live manifest-attestation check) so users can read them off the running page and compare off-CDN — a
-  convenience layer over this OOB trust root, never a substitute for it. See `docs/oob-verification.md`.
+  convenience layer over this OOB trust root, never a substitute for it. The live check's verdict is
+  split by which test failed: only a **signature failure or a revoked kid** (i.e. a swapped key) raises
+  the loud bar, while "no live epoch published / the one served had expired" and "endpoint unreachable"
+  stay quiet panel detail, since all of those leave the client sealing to the pinned static key and a
+  CDN can already force that fallback by blocking the endpoint. See `docs/oob-verification.md`
+  § "What the live attestation check reports".
 
 ## Documented residual limits
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1054,6 +1054,7 @@
     "attestationEpoch": "Current key {kid}, expires {expiry}.",
     "attestationFail": "Could not verify the server's current key - a network problem, or a CDN tampering with the key endpoint. Verify out-of-band before continuing.",
     "attestationUnreachable": "The live key check is temporarily unavailable. Your connection still uses the verified key built into the app.",
+    "attestationStale": "The server isn't publishing a current rotating key right now, so your connection is using the verified key built into the app. Nothing here suggests tampering.",
     "attestationUnconfigured": "Live key checking isn't set up on this build.",
     "compareHeading": "How to verify",
     "compareBody": "Compare the fingerprints above against the values published through a channel this server doesn't control. They must match.",

--- a/src/client/components/E2eeVerifyModal.svelte
+++ b/src/client/components/E2eeVerifyModal.svelte
@@ -62,7 +62,9 @@
   // Attestation comes from the shared store (one fetch across badge + panel).
   $effect(() => {
     if (!open) return;
-    void ensureAttestationChecked();
+    // `force`: opening the panel is an explicit "check this now", so it bypasses the
+    // re-check throttle rather than showing a verdict from minutes ago.
+    void ensureAttestationChecked({ force: true });
     void import('../lib/e2ee').then(async (m) => {
       const p = m.e2eePins();
       pins = { hpkeKid: p.hpkeKid, suiteId: p.suiteId };
@@ -163,6 +165,8 @@
           <p class="inline-flex items-center gap-1.5 text-destructive">
             <ShieldAlert class="size-4 shrink-0" />{t('e2ee.attestationFail')}
           </p>
+        {:else if e2eeSession.attestation === 'stale'}
+          <p class="text-xs text-muted-foreground">{t('e2ee.attestationStale')}</p>
         {:else if e2eeSession.attestation === 'unconfigured'}
           <p class="text-xs text-muted-foreground">{t('e2ee.attestationUnconfigured')}</p>
         {:else}

--- a/src/client/lib/e2ee-attestation.test.ts
+++ b/src/client/lib/e2ee-attestation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { classifyAttestation } from './e2ee-attestation';
+
+describe('classifyAttestation', () => {
+  test('a verified epoch is active', () => {
+    expect(
+      classifyAttestation({ reachable: true, attested: true, epochKid: 'k', notAfter: Date.now() }),
+    ).toBe('active');
+  });
+
+  test('a manifest-signature failure is the loud warn (the CDN-tamper tell)', () => {
+    expect(classifyAttestation({ reachable: true, attested: false, failure: 'signature' })).toBe(
+      'warn',
+    );
+  });
+
+  test('a revoked kid is also loud', () => {
+    expect(classifyAttestation({ reachable: true, attested: false, failure: 'revoked' })).toBe(
+      'warn',
+    );
+  });
+
+  // The bug this guards: an expired or absent epoch means the server has no live
+  // key (rotation behind, or a cache served us an old response) and the client
+  // falls back to the pinned static key. That used to raise the same "don't enter
+  // your account number" banner as an actual key swap.
+  test('an expired epoch is a quiet operator signal, not a tamper warning', () => {
+    expect(classifyAttestation({ reachable: true, attested: false, failure: 'expired' })).toBe(
+      'stale',
+    );
+  });
+
+  test('no published epoch is a quiet operator signal too', () => {
+    expect(classifyAttestation({ reachable: true, attested: false, failure: 'absent' })).toBe(
+      'stale',
+    );
+  });
+
+  test('an unreachable endpoint stays quiet (the pinned key is still in use)', () => {
+    expect(classifyAttestation({ reachable: false, attested: false })).toBe('unreachable');
+  });
+
+  test('a build with no manifest key baked reports unconfigured, not a failure', () => {
+    expect(classifyAttestation({ reachable: false, attested: false, configured: false })).toBe(
+      'unconfigured',
+    );
+  });
+});

--- a/src/client/lib/e2ee-attestation.test.ts
+++ b/src/client/lib/e2ee-attestation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { classifyAttestation } from './e2ee-attestation';
+import { classifyAttestation, nextAttestation } from './e2ee-attestation';
 
 describe('classifyAttestation', () => {
   test('a verified epoch is active', () => {
@@ -44,5 +44,30 @@ describe('classifyAttestation', () => {
     expect(classifyAttestation({ reachable: false, attested: false, configured: false })).toBe(
       'unconfigured',
     );
+  });
+});
+
+describe('nextAttestation', () => {
+  // Re-attesting must not hand a caught CDN an off switch: having been detected, it
+  // could otherwise clear the banner by making the next poll inconclusive.
+  test('a raised warn survives every inconclusive later verdict', () => {
+    for (const later of ['stale', 'unreachable', 'pending'] as const) {
+      expect(nextAttestation('warn', later)).toBe('warn');
+    }
+  });
+
+  test('only a positive attestation clears a warn', () => {
+    expect(nextAttestation('warn', 'active')).toBe('active');
+  });
+
+  test('a warn still raises from any other state', () => {
+    expect(nextAttestation('active', 'warn')).toBe('warn');
+    expect(nextAttestation('stale', 'warn')).toBe('warn');
+  });
+
+  test('non-warn states track the fresh verdict', () => {
+    expect(nextAttestation('active', 'stale')).toBe('stale');
+    expect(nextAttestation('unreachable', 'active')).toBe('active');
+    expect(nextAttestation('pending', 'unreachable')).toBe('unreachable');
   });
 });

--- a/src/client/lib/e2ee-attestation.ts
+++ b/src/client/lib/e2ee-attestation.ts
@@ -41,3 +41,17 @@ export function classifyAttestation(att: ConnectionAttestation): E2eeAttestation
   if (!att.reachable) return 'unreachable';
   return att.failure && TAMPER_FAILURES.includes(att.failure) ? 'warn' : 'stale';
 }
+
+/**
+ * Fold a fresh verdict into the one already on screen. `warn` is STICKY: once a
+ * swapped or revoked key has been observed, only a poll that positively attests
+ * may clear the alarm.
+ *
+ * Without this, re-attesting hands an active CDN an off switch - having been
+ * caught once, it clears the "don't enter your account number" banner just by
+ * making the next poll inconclusive (block it → `unreachable`, or strip/expire the
+ * epoch → `stale`). Inconclusive is not exculpatory, so it does not clear.
+ */
+export function nextAttestation(prev: E2eeAttestation, next: E2eeAttestation): E2eeAttestation {
+  return prev === 'warn' && next !== 'active' ? 'warn' : next;
+}

--- a/src/client/lib/e2ee-attestation.ts
+++ b/src/client/lib/e2ee-attestation.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure mapping from a live key-attestation result to the UI verdict the chrome
+ * renders. Kept out of `e2ee-status.svelte.ts` so it is unit-testable without the
+ * Svelte compiler (that module carries runes) and out of `e2ee.ts` so reading it
+ * costs no crypto chunk.
+ */
+import type { AttestationFailure, ConnectionAttestation } from './e2ee';
+
+export type E2eeAttestation =
+  | 'pending'
+  | 'active'
+  | 'warn'
+  | 'stale'
+  | 'unreachable'
+  | 'unconfigured';
+
+/** The failures that mean someone swapped the key, rather than that the server has none. */
+const TAMPER_FAILURES: readonly AttestationFailure[] = ['signature', 'revoked'];
+
+/**
+ * Fold one attestation result into a UI verdict:
+ *
+ *  - `active`      key verified against the baked manifest key, unexpired, not revoked.
+ *  - `warn`        the endpoint answered and the key it served FAILS to verify, or is
+ *                  revoked. Only a CDN swapping the key produces this, so it is the
+ *                  one state escalated loudly (the full-width <E2eeAlert/> bar).
+ *  - `stale`       the endpoint answered but has no live epoch to offer (none
+ *                  published, or the one we got had expired). The client keeps
+ *                  sealing to the manifest-pinned STATIC key, so nothing is
+ *                  unprotected and nothing points at tampering: this is an operator
+ *                  signal (rotation wedged, or a cache handed us an old response)
+ *                  and shows only as detail in the verify panel. It must NOT reuse
+ *                  `warn` - saying "don't enter your account number" because a cron
+ *                  is behind trains users to ignore the one alarm that counts.
+ *  - `unreachable` couldn't reach the endpoint (a network blip); the pinned key is
+ *                  still in use, so this is NOT an alarm either.
+ */
+export function classifyAttestation(att: ConnectionAttestation): E2eeAttestation {
+  if (att.configured === false) return 'unconfigured'; // manifest key not baked: can't verify
+  if (att.attested) return 'active';
+  if (!att.reachable) return 'unreachable';
+  return att.failure && TAMPER_FAILURES.includes(att.failure) ? 'warn' : 'stale';
+}

--- a/src/client/lib/e2ee-status.svelte.ts
+++ b/src/client/lib/e2ee-status.svelte.ts
@@ -11,6 +11,10 @@
  * lazy. `ensureAttestationChecked()` lazy-imports `e2ee.ts` only on demand, so a
  * dark build whose badge never renders the active branch never pulls the chunk.
  */
+import { classifyAttestation, type E2eeAttestation } from './e2ee-attestation';
+
+export { classifyAttestation };
+export type { E2eeAttestation };
 
 /**
  * COMPILE-TIME read of the baked pins (same expression as api.ts E2EE_ENABLED and
@@ -20,8 +24,6 @@
  */
 const SEALING_CONFIGURED =
   !!import.meta.env.VITE_FS_SERVER_HPKE_PK && !!import.meta.env.VITE_FS_SERVER_HPKE_KID;
-
-export type E2eeAttestation = 'pending' | 'active' | 'warn' | 'unreachable' | 'unconfigured';
 
 export const e2eeSession = $state<{
   lastSealedAt: number | null;
@@ -44,36 +46,73 @@ export function markSealedResponse(): void {
   e2eeSession.lastSealedAt = Date.now();
 }
 
-let attestationStarted = false;
+/** Don't re-hit the key endpoint more often than this (its own max-age is 60s). */
+const MIN_RECHECK_MS = 60_000;
+/** Re-attest this often, so a tab left open for days isn't stuck on a stale verdict. */
+const RECHECK_INTERVAL_MS = 5 * 60_000;
 
-/**
- * Run the read-only live key attestation once per page load and fold the verdict
- * into `e2eeSession`. Verdicts:
- *  - `active`      key verified against the baked manifest key, unexpired, not revoked.
- *  - `warn`        the endpoint answered but the key FAILS to verify (expired/revoked
- *                  or a CDN tampering with /api/v1/e2ee/keys) - the active-CDN tamper
- *                  tell; this is the one state that must be surfaced loudly.
- *  - `unreachable` couldn't reach the endpoint (a network blip); the pinned key is
- *                  still in use, so this is NOT an alarm.
- * Lazy-imports the crypto chunk so the light badge can trigger it without eagerly
- * loading `e2ee.ts`. Idempotent - the first caller wins, later callers no-op.
- */
-export async function ensureAttestationChecked(): Promise<void> {
-  if (!SEALING_CONFIGURED) return; // dark build: compile-time false → import() below is tree-shaken
-  if (attestationStarted) return;
-  attestationStarted = true;
+let lastCheckedAt = 0;
+let inFlight: Promise<void> | null = null;
+let hooksInstalled = false;
+
+async function runAttestation(): Promise<void> {
   const { verifyConnection } = await import('./e2ee');
   const att = await verifyConnection();
+  lastCheckedAt = Date.now();
   e2eeSession.epochKid = att.epochKid ?? null;
   e2eeSession.notAfter = att.notAfter ?? null;
-  e2eeSession.attestation =
-    att.configured === false
-      ? 'unconfigured' // manifest key not baked: can't verify (not a network fault)
-      : att.attested
-        ? 'active'
-        : att.reachable
-          ? 'warn'
-          : 'unreachable';
+  e2eeSession.attestation = classifyAttestation(att);
+}
+
+/**
+ * Re-run the live key attestation and fold the fresh verdict into `e2eeSession`.
+ * Throttled to one call per MIN_RECHECK_MS (pass `force` for an explicit user
+ * action, e.g. opening the verify panel), and single-flighted so a burst of
+ * triggers - the interval firing as a tab is refocused - is one request.
+ */
+export async function refreshAttestation(opts?: { force?: boolean }): Promise<void> {
+  if (!SEALING_CONFIGURED) return; // dark build: compile-time false → import() is tree-shaken
+  if (inFlight) return inFlight;
+  if (!opts?.force && Date.now() - lastCheckedAt < MIN_RECHECK_MS) return;
+  inFlight = runAttestation().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+/**
+ * Keep the verdict live for the lifetime of the tab. Without this the check ran
+ * exactly once per page load, so a tab left open (or, worse, silently reloaded
+ * from cache by a browser restoring a discarded tab) kept whatever verdict it
+ * first computed - including a scary banner that a single manual refresh cleared.
+ *
+ * The interval is the failsafe and runs unconditionally; refocus + regained
+ * connectivity are extra nudges on top of it. Deliberately NOT gated on
+ * `visibilityState === 'visible'`: some embedded webviews report a displayed page
+ * as hidden forever, which would silently disable the whole refresh. Browsers
+ * throttle background timers on their own, and the throttle below plus the key
+ * endpoint's per-IP policy bound the cost either way.
+ */
+function installRefreshHooks(): void {
+  if (hooksInstalled || typeof document === 'undefined') return;
+  hooksInstalled = true;
+  const refresh = () => void refreshAttestation();
+  document.addEventListener('visibilitychange', refresh);
+  window.addEventListener('online', refresh);
+  setInterval(refresh, RECHECK_INTERVAL_MS);
+}
+
+/**
+ * Run the live key attestation for this page and keep it fresh from then on.
+ * Idempotent: the first caller starts the check and installs the refresh hooks,
+ * later callers fall through to the throttled `refreshAttestation`.
+ * Lazy-imports the crypto chunk so the light badge can trigger it without eagerly
+ * loading `e2ee.ts`.
+ */
+export async function ensureAttestationChecked(opts?: { force?: boolean }): Promise<void> {
+  if (!SEALING_CONFIGURED) return; // dark build: compile-time false → import() is tree-shaken
+  installRefreshHooks();
+  await refreshAttestation(opts);
 }
 
 /** Open the shared "Verify connection" modal from anywhere (badge or alert). */

--- a/src/client/lib/e2ee-status.svelte.ts
+++ b/src/client/lib/e2ee-status.svelte.ts
@@ -11,7 +11,7 @@
  * lazy. `ensureAttestationChecked()` lazy-imports `e2ee.ts` only on demand, so a
  * dark build whose badge never renders the active branch never pulls the chunk.
  */
-import { classifyAttestation, type E2eeAttestation } from './e2ee-attestation';
+import { classifyAttestation, nextAttestation, type E2eeAttestation } from './e2ee-attestation';
 
 export { classifyAttestation };
 export type { E2eeAttestation };
@@ -59,9 +59,16 @@ async function runAttestation(): Promise<void> {
   const { verifyConnection } = await import('./e2ee');
   const att = await verifyConnection();
   lastCheckedAt = Date.now();
-  e2eeSession.epochKid = att.epochKid ?? null;
-  e2eeSession.notAfter = att.notAfter ?? null;
-  e2eeSession.attestation = classifyAttestation(att);
+  const verdict = classifyAttestation(att);
+  const held = nextAttestation(e2eeSession.attestation, verdict);
+  // A `warn` held over an inconclusive poll keeps the epoch fields from the
+  // observation that raised it: overwriting them would erase what tripped the alarm
+  // while the alarm is still showing.
+  if (held === verdict) {
+    e2eeSession.epochKid = att.epochKid ?? null;
+    e2eeSession.notAfter = att.notAfter ?? null;
+  }
+  e2eeSession.attestation = held;
 }
 
 /**

--- a/src/client/lib/e2ee.ts
+++ b/src/client/lib/e2ee.ts
@@ -193,19 +193,24 @@ function applyRevocation(r: {
 }
 
 /**
- * Fetch the server-attested key material, never accepting a cached body without
- * asking the origin first.
+ * Fetch the server-attested key material under NORMAL cache rules, deliberately.
  *
- * An epoch that has expired is indistinguishable at the crypto layer from one an
- * attacker swapped in, so a cache that hands back a long-dead response corrupts the
- * verdict (and silently keeps the seal path on the static key, losing the epoch's
- * forward secrecy). `cache: 'no-cache'` rather than `'no-store'`: it forbids using a
- * cached response unvalidated - the actual guarantee we need - while still letting
- * the cache be populated and a cheap 304 answer the revalidation, so the endpoint's
- * own `max-age` keeps working for shared caches.
+ * An expired epoch is indistinguishable at the crypto layer from one an attacker
+ * swapped in, and the fix for that lives on the server: the endpoint clamps its
+ * `max-age` to the epoch's own remaining validity (`no-store` during a rotation
+ * gap), so no conformant cache can hand back a dead key. That clamp is load-bearing
+ * - raising max-age past the validity would reintroduce the bug.
+ *
+ * Forcing revalidation from here instead (`no-store` / `no-cache`, both tried) is
+ * WORSE for the population this serves: the fetch-spec cache modes send
+ * `max-age=0`, which punches every request past the CDN to the origin, where the
+ * per-IP `e2ee.keys.fetch` policy lives. A per-browser cache saves nothing for many
+ * distinct clients behind one carrier-grade NAT - only the shared CDN cache does -
+ * so bypassing it trades a bounded, quiet staleness for 429s and a silent
+ * static-key fallback exactly where censorship makes NAT sharing the norm.
  */
 function fetchKeys(): Promise<Response> {
-  return fetch('/api/v1/e2ee/keys', { credentials: 'omit', cache: 'no-cache' });
+  return fetch('/api/v1/e2ee/keys', { credentials: 'omit' });
 }
 
 async function refreshEpoch(): Promise<void> {

--- a/src/client/lib/e2ee.ts
+++ b/src/client/lib/e2ee.ts
@@ -192,10 +192,24 @@ function applyRevocation(r: {
   }
 }
 
+/**
+ * Fetch the server-attested key material, ALWAYS from the origin.
+ *
+ * The response carries a short `max-age` so shared caches can absorb bursts, but
+ * the browser's own HTTP cache must never answer this: an epoch is valid for 30
+ * minutes, so a cache hit on a long-idle tab (a session-restore reload prefers the
+ * disk cache over revalidating) hands back an EXPIRED epoch, which is
+ * indistinguishable at the crypto layer from a tampered one. `cache: 'no-store'`
+ * keeps the verdict about the live server instead of about our own cache.
+ */
+function fetchKeys(): Promise<Response> {
+  return fetch('/api/v1/e2ee/keys', { credentials: 'omit', cache: 'no-store' });
+}
+
 async function refreshEpoch(): Promise<void> {
   if (!MANIFEST_PK) return;
   try {
-    const res = await fetch('/api/v1/e2ee/keys', { credentials: 'omit' });
+    const res = await fetchKeys();
     if (!res.ok) return;
     const body = (await res.json()) as {
       epoch?: {
@@ -248,11 +262,22 @@ async function currentEpoch(): Promise<{ kid: string; pub: CryptoKey } | null> {
   return e ? { kid: e.kid, pub: e.pub } : null;
 }
 
+/**
+ * Why an attestation did not attest, when the endpoint DID answer. Only
+ * `signature` and `revoked` are tamper tells (a CDN swapping the key, or a key we
+ * were told to refuse); `absent` and `expired` mean the server has no live epoch
+ * to offer, so the client keeps sealing to the pinned static key. See
+ * `classifyAttestation` in ./e2ee-status.svelte.ts for how each maps to UI.
+ */
+export type AttestationFailure = 'absent' | 'expired' | 'signature' | 'revoked';
+
 export interface ConnectionAttestation {
   /** The /api/v1/e2ee/keys endpoint responded. */
   reachable: boolean;
   /** The current epoch key verified against the baked manifest key(s), unexpired + not revoked. */
   attested: boolean;
+  /** Set when `reachable` but not `attested`, saying WHICH check failed. */
+  failure?: AttestationFailure;
   /**
    * The live attestation is even possible on this build: false when the manifest
    * public key wasn't baked, so we CANNOT verify (distinct from "reachable but the
@@ -281,7 +306,7 @@ export async function verifyConnection(): Promise<ConnectionAttestation> {
     return { reachable: false, attested: false, configured: false };
   }
   try {
-    const res = await fetch('/api/v1/e2ee/keys', { credentials: 'omit' });
+    const res = await fetchKeys();
     if (!res.ok) return { reachable: false, attested: false };
     const body = (await res.json()) as {
       epoch?: {
@@ -316,16 +341,29 @@ export async function verifyConnection(): Promise<ConnectionAttestation> {
       revocationVersion = r.version;
     }
     const e = body.epoch;
-    if (!e) return { reachable: true, attested: false, revocationVersion };
-    const attested =
-      verifyManifestHybrid(
-        epochStatement({ kid: e.kid, publicKeyB64: e.publicKey, notAfter: e.notAfter }),
-        e.sig,
-        e.sigPq,
-      ) &&
-      e.notAfter > Date.now() &&
-      !isRevoked(e.kid);
-    return { reachable: true, attested, epochKid: e.kid, notAfter: e.notAfter, revocationVersion };
+    if (!e) return { reachable: true, attested: false, failure: 'absent', revocationVersion };
+    // Order matters: report the TAMPER tells (bad signature, revoked kid) ahead of
+    // "expired", so a benignly stale epoch is never reported as an attack and an
+    // attack is never excused as staleness.
+    const failure: AttestationFailure | undefined = !verifyManifestHybrid(
+      epochStatement({ kid: e.kid, publicKeyB64: e.publicKey, notAfter: e.notAfter }),
+      e.sig,
+      e.sigPq,
+    )
+      ? 'signature'
+      : isRevoked(e.kid)
+        ? 'revoked'
+        : e.notAfter <= Date.now()
+          ? 'expired'
+          : undefined;
+    return {
+      reachable: true,
+      attested: !failure,
+      ...(failure ? { failure } : {}),
+      epochKid: e.kid,
+      notAfter: e.notAfter,
+      revocationVersion,
+    };
   } catch {
     return { reachable: false, attested: false };
   }

--- a/src/client/lib/e2ee.ts
+++ b/src/client/lib/e2ee.ts
@@ -193,17 +193,19 @@ function applyRevocation(r: {
 }
 
 /**
- * Fetch the server-attested key material, ALWAYS from the origin.
+ * Fetch the server-attested key material, never accepting a cached body without
+ * asking the origin first.
  *
- * The response carries a short `max-age` so shared caches can absorb bursts, but
- * the browser's own HTTP cache must never answer this: an epoch is valid for 30
- * minutes, so a cache hit on a long-idle tab (a session-restore reload prefers the
- * disk cache over revalidating) hands back an EXPIRED epoch, which is
- * indistinguishable at the crypto layer from a tampered one. `cache: 'no-store'`
- * keeps the verdict about the live server instead of about our own cache.
+ * An epoch that has expired is indistinguishable at the crypto layer from one an
+ * attacker swapped in, so a cache that hands back a long-dead response corrupts the
+ * verdict (and silently keeps the seal path on the static key, losing the epoch's
+ * forward secrecy). `cache: 'no-cache'` rather than `'no-store'`: it forbids using a
+ * cached response unvalidated - the actual guarantee we need - while still letting
+ * the cache be populated and a cheap 304 answer the revalidation, so the endpoint's
+ * own `max-age` keeps working for shared caches.
  */
 function fetchKeys(): Promise<Response> {
-  return fetch('/api/v1/e2ee/keys', { credentials: 'omit', cache: 'no-store' });
+  return fetch('/api/v1/e2ee/keys', { credentials: 'omit', cache: 'no-cache' });
 }
 
 async function refreshEpoch(): Promise<void> {

--- a/src/client/lib/i18n/message-keys.ts
+++ b/src/client/lib/i18n/message-keys.ts
@@ -152,6 +152,7 @@ export type MessageKey =
   | "e2ee.attestationFail"
   | "e2ee.attestationHeading"
   | "e2ee.attestationOk"
+  | "e2ee.attestationStale"
   | "e2ee.attestationUnconfigured"
   | "e2ee.attestationUnreachable"
   | "e2ee.badgeActiveTitle"


### PR DESCRIPTION
## The bug

Leaving the site open for a day or two eventually showed the loud red bar:

> **Couldn't verify the encryption key** · Don't enter your account number yet - verify this connection out-of-band first.

A manual refresh cleared it. That bar is the CDN-tamper alarm, and it was firing on entirely benign conditions.

## Cause 1: every non-attesting outcome looked like tampering

`verifyConnection()` collapsed all four "endpoint answered but the key didn't attest" outcomes into one verdict:

| Condition | What it actually means | Old verdict |
| --- | --- | --- |
| manifest signature fails | someone swapped the key | 🔴 loud bar |
| kid is revoked | a key we are told to refuse | 🔴 loud bar |
| `epoch: null` | the server has no live epoch (rotation gap) | 🔴 loud bar |
| epoch already expired | a cache handed us an old response | 🔴 loud bar |

In the bottom two rows the client keeps sealing to the manifest-pinned **static** key, so nothing was ever sent unprotected. Only the alarm was wrong — and a loud alarm that fires on a wedged cron teaches users to dismiss the one that matters.

**Fix:** `verifyConnection` now returns a `failure` discriminant (`absent | expired | signature | revoked`), and the pure `classifyAttestation` (`src/client/lib/e2ee-attestation.ts`) escalates only `signature`/`revoked` to the loud bar. `absent`/`expired` become a quiet new `stale` verdict, explained in the verify panel.

This concedes nothing to an attacker: a CDN that wants the static-key fallback can already force it by simply blocking the endpoint, which has always been silent (`unreachable`).

## Cause 2: the verdict was frozen at page load

The check ran exactly once per page load and was then fixed for the tab's lifetime, so a verdict could never clear on its own — hence "a refresh fixes it".

**Fix:** a 5-minute interval plus refocus/`online` nudges re-attest in place (throttled to 1/min, single-flighted); opening the verify panel forces a fresh check. Deliberately **not** a page auto-reload, which would wipe a revealed account number mid-signup.

`warn` is **sticky** across those re-checks (added in 610af57, from review): once a swapped or revoked key has been observed, only a poll that positively attests clears it. Otherwise re-attesting would hand a caught CDN an off switch — block the next request, or serve an epoch-less body, and the banner disappears. Inconclusive is not exculpatory.

## Cache hardening

An expired epoch is indistinguishable from a tampered one, so the **server** is what keeps a cache from creating that state: the endpoint clamps its `max-age` to the epoch's own remaining validity and sends `no-store` during a rotation gap. That clamp is load-bearing — raising `max-age` past the epoch validity would reintroduce the bug.

The client reads the endpoint under **normal cache rules**. Two revisions of this PR forced revalidation (`no-store`, then `no-cache`) before review talked me out of it, correctly: both fetch-spec modes send `max-age=0`, which punches every request past the CDN to the origin where the per-IP `e2ee.keys.fetch` policy lives, and a per-browser cache saves nothing for many distinct clients behind one carrier-grade NAT. Bypassing the shared cache would trade a bounded, now-quiet staleness for 429s and a silent static-key fallback precisely where censorship makes NAT sharing the norm.

Note on likelihood, since the first commit message overstated the cache path: rotation every 10 minutes against a 30-minute validity means the epoch on the wire normally has 20+ minutes left, so a conformant 60-second cache could not have served an expired one. The clamp is a guarantee rather than the trigger, and the likelier trigger was a transient inconclusive response — `epoch: null` during a rotation gap being the obvious candidate — which the classification fix addresses directly.

## Ruled out

- **Not a currently-wedged rotate cron.** Both live stacks were rotating normally when checked (`/api/v1/e2ee/keys` returned an epoch with ~21-26 min left). A gap days ago is still consistent with the report.
- **Not a manifest-key rotation between deploys.** `scripts/bootstrap-secrets.mjs` generates the keypair once, idempotently.

## Reviewer notes

- The security-relevant calls are the loud/quiet split and the stickiness of `warn`. Both are documented in `docs/oob-verification.md` § "What the live attestation check reports" (with a verdict table) and summarized in `docs/threat-model-cdn-blinding.md`.
- The refresh interval is **intentionally not** gated on `document.visibilityState === 'visible'`: some embedded webviews report a displayed page as hidden forever, which would silently disable the whole refresh. Browsers throttle background timers themselves, and the 1/min throttle plus normal cache behavior bound the origin load. A 429 classifies as `unreachable`: quiet, pinned static key, no banner.
- New i18n key `e2ee.attestationStale` is **en-only**, per the human-translation-only policy; other locales fall back to en pending native review.

## Verification

- 1201 tests pass, typecheck and lint clean. New unit tests for `classifyAttestation` and `nextAttestation`; the `cache-control` tests cover the clamp, the 60s ceiling, and the no-cache-on-gap case.
- Driven in a real browser against a mock key endpoint:
  - `epoch: null` → no bar, badge stays green, panel reads the new quiet copy
  - forged signature → bar and amber badge still fire, unchanged
  - a resolved warning → clears itself in place, with no reload
  - a raised warning → **survives an epoch-less poll that reaches the server** (before 610af57, that sequence cleared it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
