### PR TITLE
chore(docker): pin Cap to the 3.1.8 semver tag instead of latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,9 +37,11 @@ updates:
   # See the comment on the `backend` service in docker-compose.stack.yml.
   #
   # Two of the remaining ones want a human, not a rubber stamp:
-  #  - `tiago2/cap:latest` is the accepted-risk image (docs/beta-deploy.md
-  #    § "Cap image provenance"), tracked by digest on a floating tag — the PR
-  #    tells you the image moved, not what changed in it.
+  #  - `tiago2/cap` is the accepted-risk image (docs/beta-deploy.md
+  #    § "Cap image provenance"). Pinned tag@digest on a real semver tag
+  #    (was `latest` until 2026-08-25), so the PR names the actual version
+  #    jump — check the upstream release notes (tiagorangel1/cap, releases
+  #    tagged `standalone@<version>`) before merging.
   #  - `remnawave/backend` is only the throwaway integration-test panel in
   #    docker-compose.remnawave-test.yml, whose whole job is to catch provider
   #    contract drift. Bumping it is in scope, but it should track whatever

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -215,8 +215,11 @@ services:
   # admin paths); the backend verifies tokens over the compose network
   # (CAP_API_ENDPOINT=http://cap:3000).
   cap:
-    # Pinned by digest (re-pin on upgrade: docker buildx imagetools inspect tiago2/cap:latest).
-    image: tiago2/cap:latest@sha256:97455d85b5517172397c7053837d377c72ded6250777928d5435c3eab2f58779
+    # Pinned tag@digest on a real semver tag (upstream release standalone@3.1.8),
+    # NOT `latest` — so a Dependabot bump names the actual version change instead
+    # of "latest moved". Re-pin by hand if needed:
+    # docker buildx imagetools inspect tiago2/cap:<version>.
+    image: tiago2/cap:3.1.8@sha256:56d402dc15e536b4c20e341a81bb9e78a0082b833e4337b9b05b242d96e0ffe5
     pids_limit: 256
     restart: unless-stopped
     logging: *log


### PR DESCRIPTION
The `cap` service was digest-pinned on the floating `latest` tag, so a Dependabot re-pin PR could only say "latest moved" with no version information. This pins tag@digest on the real semver tag instead — `tiago2/cap:3.1.8` (upstream release `standalone@3.1.8`) — so future bumps arrive as named version changes with release notes to review.

Notes:
- The previously pinned digest was the `3.1.5` build, so deploying this is also a 3.1.5 → 3.1.8 upgrade of the Cap service.
- Upstream `latest` currently sits at 3.1.9; once this merges, Dependabot will propose 3.1.8 → 3.1.9 as a normal named bump.
- The stale `tiago2/cap:latest` note in `.github/dependabot.yml` is updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)