### PR TITLE
ci(convex): monthly ship.convex.dev-anchored backend re-pin flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: shellcheck the docker scripts
+      - name: shellcheck the docker and repo scripts
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
-          shellcheck -S error docker/*.sh
+          shellcheck -S error docker/*.sh scripts/*.sh
       - name: Build docker images (no cache)
         run: |
           docker build -f docker/web.Dockerfile .

--- a/.github/workflows/convex-release-watch.yml
+++ b/.github/workflows/convex-release-watch.yml
@@ -6,10 +6,15 @@
 # keeping anyway: it names a GitHub release, and `git log <pinned>..<target>` is
 # the only changelog Convex still publishes for self-hosted.
 #
-# This job is the replacement notification. It files (and keeps updating) a
-# single issue while newer releases exist, and closes it once the pin catches
-# up — so the pin cannot quietly rot the way the backup sidecar's image did for
-# four weeks in Aug 2026.
+# This job is the ESCALATION detector for the monthly re-pin flow
+# (.github/workflows/convex-repin.yml opens the actual bump PR; runbook:
+# docs/beta-deploy.md § Upgrading the Convex backend). Convex ships near-daily,
+# so on a monthly cadence the pin is always some releases behind — that is
+# healthy and files nothing. Only a pin whose release is older than
+# STALE_AFTER_DAYS (7-day upstream buffer + a monthly cycle + merge/soak/prod
+# slack) means the flow has stalled; then this files (and keeps updating) a
+# single issue, and closes it once the pin is fresh again — so the pin cannot
+# quietly rot the way the backup sidecar's image did for four weeks in Aug 2026.
 name: Convex release watch
 
 on:
@@ -21,6 +26,8 @@ on:
 permissions:
   contents: read
   issues: write
+  # Read-only, for naming an open convex-repin/* PR in the issue body.
+  pull-requests: read
 
 jobs:
   watch:
@@ -28,11 +35,18 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       UPSTREAM: get-convex/convex-backend
-      ISSUE_TITLE: 'Convex self-hosted: pinned release is behind upstream'
+      ISSUE_TITLE: 'Convex self-hosted: pinned release is stale (monthly re-pin has stalled)'
+      # The pre-2026-08 title; searched as a fallback and retitled in place so
+      # the original issue's history survives the rename. Drop once no issue
+      # with this title can still exist.
+      LEGACY_ISSUE_TITLE: 'Convex self-hosted: pinned release is behind upstream'
+      # 7d upstream age buffer + ~31d monthly cycle + ~10d merge/soak/prod
+      # slack. A healthy flow never exceeds this; tune here if it cries wolf.
+      STALE_AFTER_DAYS: '49'
     steps:
       - uses: actions/checkout@v7
 
-      - name: Compare the pinned Convex release against upstream
+      - name: Check the pinned Convex release's age against the policy window
         run: |
           set -euo pipefail
 
@@ -46,30 +60,51 @@ jobs:
 
           # Releases are `precompiled-<date>-<sha7>`, newest first.
           gh api --paginate "/repos/$UPSTREAM/releases?per_page=100" \
-            --jq '.[].tag_name' > releases.txt
+            --jq '.[] | [.tag_name, .published_at] | @tsv' > releases.tsv
 
-          line="$(grep -nE -- "-${short}\$" releases.txt | head -1 | cut -d: -f1 || true)"
+          line="$(awk -F'\t' -v s="$short" '$1 ~ ("-" s "$") { print NR; exit }' releases.tsv)"
           if [ -z "$line" ]; then
             echo "::error::pinned sha $short matches no $UPSTREAM release — someone pinned an untagged build. Re-pin to a release."
             exit 1
           fi
           behind=$((line - 1))
-          pinned_tag="$(sed -n "${line}p" releases.txt)"
-          newest="$(head -1 releases.txt)"
-          echo "pinned $pinned_tag is $behind release(s) behind; newest is $newest"
+          pinned_tag="$(awk -F'\t' -v n="$line" 'NR == n { print $1 }' releases.tsv)"
+          pinned_published="$(awk -F'\t' -v n="$line" 'NR == n { print $2 }' releases.tsv)"
+          newest="$(head -1 releases.tsv | cut -f1)"
+          now_s="$(date -u +%s)"
+          pinned_s="$(date -u -d "$pinned_published" +%s)"
+          pin_age=$(((now_s - pinned_s) / 86400))
+          echo "pinned $pinned_tag is ${pin_age}d old ($behind release(s) behind; newest is $newest)"
 
           existing="$(gh issue list --state open --search "\"$ISSUE_TITLE\" in:title" \
             --json number --jq '.[0].number // empty')"
+          if [ -z "$existing" ]; then
+            existing="$(gh issue list --state open --search "\"$LEGACY_ISSUE_TITLE\" in:title" \
+              --json number --jq '.[0].number // empty')"
+          fi
 
-          if [ "$behind" -eq 0 ]; then
+          if [ "$pin_age" -lt "$STALE_AFTER_DAYS" ]; then
+            # Healthy: the monthly flow is working. Being some releases behind
+            # is expected — Convex ships near-daily and the cadence is monthly.
             if [ -n "$existing" ]; then
-              gh issue close "$existing" --comment "Pin is current again ($newest). Closing automatically."
+              gh issue close "$existing" --comment "Pin is \`$pinned_tag\`, published ${pin_age}d ago — inside the ${STALE_AFTER_DAYS}-day policy window ($behind release(s) behind is expected on a monthly cadence). Closing automatically."
             fi
             exit 0
           fi
 
+          # Stalled: name the unmerged re-pin PR if one exists, so the issue is
+          # a precise nudge rather than a generic alarm.
+          open_pr="$(gh pr list --state open --json number,headRefName,createdAt \
+            --jq '[.[] | select(.headRefName | startswith("convex-repin/"))][0] | if . == null then "" else "PR #\(.number) (\(.headRefName)) has been open since \(.createdAt[0:10]) — merge or close it." end')"
+          if [ -z "$open_pr" ]; then
+            open_pr="No convex-repin/* PR is open — check .github/workflows/convex-repin.yml for a failed or skipped run."
+          fi
+
           cat > body.md <<EOF
-          The stack pins Convex at \`$short\`; upstream is **$behind release(s)** ahead.
+          The stack pins Convex at \`$pinned_tag\`, published **${pin_age} days ago** —
+          past the ${STALE_AFTER_DAYS}-day policy window. The monthly re-pin flow has stalled.
+
+          $open_pr
 
           | | |
           |---|---|
@@ -79,27 +114,23 @@ jobs:
 
           Convex stopped maintaining \`self-hosted/CHANGELOG.md\` in 2025-09 ("check
           \`git log\` for a detailed listing of changes"), so that compare view **is** the
-          changelog. Read it before upgrading.
+          changelog. It is pinned release to newest release, deliberately — NOT
+          \`...HEAD\`: Convex ships most days, so HEAD is normally ahead of the newest
+          release and a \`...HEAD\` range would show commits that are not in the
+          upgrade you are being offered.
 
-          It is pinned release to newest release, deliberately — NOT \`...HEAD\`. Convex
-          ships most days, so HEAD is normally ahead of the newest release and a
-          \`...HEAD\` range would show commits that are not in the upgrade you are
-          being offered.
-
-          Upgrading (\`self-hosted/advanced/upgrading.md\`):
-
-          1. Take an export first — upgrades run in-place DB migrations.
-          2. Re-pin **both** \`convex-backend\` and \`convex-dashboard\` in
-             \`docker-compose.stack.yml\` to the same new git sha, with fresh digests.
-             They must match, and \`convex/deployPins.test.ts\` fails the build otherwise.
-          3. Deploy, then watch the backend log for \`MigrationComplete(N)\`.
+          Bump via \`gh workflow run convex-repin.yml\` (or wait for the first-Monday
+          run); the full procedure is
+          [docs/beta-deploy.md § Upgrading the Convex backend](https://github.com/${{ github.repository }}/blob/main/docs/beta-deploy.md#upgrading-the-convex-backend-image-re-pin).
 
           _Filed automatically by \`.github/workflows/convex-release-watch.yml\`._
           EOF
           sed -i 's/^          //' body.md
 
           if [ -n "$existing" ]; then
-            gh issue edit "$existing" --body-file body.md
+            # --title also migrates a legacy-titled issue in place, preserving
+            # its history instead of orphaning it and opening a duplicate.
+            gh issue edit "$existing" --title "$ISSUE_TITLE" --body-file body.md
             echo "updated issue #$existing"
           else
             gh issue create --title "$ISSUE_TITLE" --body-file body.md

--- a/.github/workflows/convex-repin.yml
+++ b/.github/workflows/convex-repin.yml
@@ -1,0 +1,370 @@
+# Monthly Convex self-hosted re-pin: opens a PR (never merges, never deploys)
+# moving the backend/dashboard/keygen pins in docker-compose.stack.yml to the
+# "anchor" build of the newest version announced on https://ship.convex.dev/.
+#
+# Why anchors: ship.convex.dev announces the `convex` npm releases (v1.45.0 and
+# friends) — the only Convex artifact with real release notes. Each maps to a
+# monorepo commit titled `npm release version X.Y.Z`; no precompiled image
+# exists at that exact commit, but the FIRST precompiled release whose commit
+# CONTAINS it is effectively the vX.Y.Z backend build (verified: the 1.45.0
+# anchor is 1 commit past the npm bump). Pinning anchors keeps the backend in
+# lockstep with the Dependabot-managed `convex` CLI in bun.lock and gives every
+# bump human-readable notes. The release-list is NOT in ancestry order (same-day
+# releases can predate the npm commit), so the containment check below is real.
+#
+# Companion: convex-release-watch.yml is the escalation watcher — it files an
+# issue only when the pin is older than its staleness threshold, i.e. when THIS
+# flow has stalled. Upgrade runbook: docs/beta-deploy.md § Upgrading the Convex
+# backend.
+#
+# The PR is opened with the default GITHUB_TOKEN, so GitHub does NOT run
+# pull_request CI on it (anti-recursion rule). To compensate, this job runs the
+# full test suite (which includes convex/deployPins.test.ts, the pin-shape
+# guard) and prettier on the exact commit before opening the PR; the PR body
+# says so and gives the close/reopen recipe for kicking full CI.
+#
+# NOTE: GitHub disables `schedule` triggers after 60 days without repo
+# activity. If both this workflow and the watcher go quiet at once, check the
+# Actions tab for a "workflow disabled" banner.
+name: Convex re-pin
+
+on:
+  schedule:
+    # Mondays 09:40 UTC (after Dependabot 09:00 + the watcher 09:15); the gate
+    # job below limits scheduled runs to the FIRST Monday of the month (cron
+    # cannot express that — day-of-month and day-of-week are OR'd).
+    - cron: '40 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Explicit npm version to anchor (e.g. 1.45.0). Empty = newest version at least min_age_days old.'
+        required: false
+        default: ''
+      release_tag:
+        description: 'Raw precompiled release tag (security escape hatch when a fix is not in any npm release yet; skips the anchor logic).'
+        required: false
+        default: ''
+      min_age_days:
+        description: 'Minimum age (days) of the npm release before it is eligible.'
+        required: false
+        default: '7'
+      dry_run:
+        description: 'Do everything except push/PR; upload the rewritten compose diff as an artifact.'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
+    steps:
+      - id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          d="$(date -u +%-d)"
+          if [ "$d" -le 7 ]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "day $d of the month — not the first Monday; skipping"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  repin:
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      UPSTREAM: get-convex/convex-backend
+      MIN_AGE_DAYS: ${{ inputs.min_age_days || '7' }}
+      INPUT_VERSION: ${{ inputs.version || '' }}
+      INPUT_RELEASE_TAG: ${{ inputs.release_tag || '' }}
+      DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && 'true' || 'false' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve the target anchor and rewrite the pins
+        id: prepare
+        run: |
+          set -euo pipefail
+
+          skip() { echo "$1"; echo "proceed=false" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          # Newest 100 releases are ~3 months of dailies — plenty; no --paginate.
+          # Convex marks EVERY precompiled daily `prerelease: true`, so do NOT
+          # filter on that flag (it would drop every real release). Filter on
+          # the tag shape instead — it also drops oddballs like
+          # `testing-precompiled-…`.
+          gh api "/repos/$UPSTREAM/releases?per_page=100" \
+            --jq '.[] | select((.draft | not) and (.tag_name | test("^precompiled-")))
+                  | [.tag_name, .published_at] | @tsv' > releases.tsv
+
+          # try_release: containment-check (unless raw) + resolve full sha +
+          # resolve BOTH image digests. Sets tag/new/bdig/ddig/ahead_by on
+          # success. GHCR image pushes LAG the releases (measured 2026-08-25:
+          # newest image was 6 days behind the newest release, and historically
+          # only ~half the releases ever get images), so "release exists" does
+          # NOT imply "image exists" — that is why this checks the images and
+          # why the callers fall forward/back on failure.
+          try_release() { # <release-tag> <npm-sha-or-empty>
+            local cand="$1" want="$2" sha7 cmp cmp_status full b d
+            sha7="${cand##*-}"
+            if [ -n "$want" ]; then
+              cmp="$(gh api "/repos/$UPSTREAM/compare/$want...$sha7" \
+                --jq '[.status, (.ahead_by | tostring)] | @tsv')" || return 1
+              # not `status`: that name is read-only in zsh, and operators
+              # paste these blocks into their shells.
+              cmp_status="$(printf '%s' "$cmp" | cut -f1)"
+              case "$cmp_status" in ahead | identical) ;; *) return 1 ;; esac
+              ahead_by="$(printf '%s' "$cmp" | cut -f2)"
+            fi
+            full="$(gh api "/repos/$UPSTREAM/commits/$sha7" --jq .sha)" || return 1
+            { [[ "$full" =~ ^[0-9a-f]{40}$ ]] && [[ "$full" == "$sha7"* ]]; } || return 1
+            # Multi-arch INDEX digest (matches the existing pin style). Fallback
+            # if buildx ever vanishes from the runner: GET ghcr.io/token
+            # (scope=repository:<image>:pull), then HEAD /v2/<image>/manifests/<tag>
+            # with BOTH index media types in Accept, and read docker-content-digest
+            # — a single Accept value silently returns a per-platform digest.
+            b="$(docker buildx imagetools inspect "ghcr.io/get-convex/convex-backend:$full" --format '{{.Manifest.Digest}}' 2>/dev/null)" \
+              || { echo "  $cand: backend image missing on GHCR"; return 1; }
+            d="$(docker buildx imagetools inspect "ghcr.io/get-convex/convex-dashboard:$full" --format '{{.Manifest.Digest}}' 2>/dev/null)" \
+              || { echo "  $cand: dashboard image missing on GHCR"; return 1; }
+            tag="$cand"
+            new="$full"
+            bdig="${b#sha256:}"
+            ddig="${d#sha256:}"
+          }
+
+          tag=''
+          new=''
+          bdig=''
+          ddig=''
+          ahead_by=''
+          ver=''
+          if [ -n "$INPUT_RELEASE_TAG" ]; then
+            # Security escape hatch: pin a raw precompiled release, no anchor.
+            [[ "$INPUT_RELEASE_TAG" =~ ^precompiled-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f]{7}$ ]] \
+              || { echo "::error::release_tag must look like precompiled-YYYY-MM-DD-<sha7>"; exit 1; }
+            try_release "$INPUT_RELEASE_TAG" '' \
+              || { echo "::error::$INPUT_RELEASE_TAG has no resolvable backend+dashboard images on GHCR"; exit 1; }
+          else
+            # ship.convex.dev versions = `npm release version X.Y.Z` commits.
+            gh api "/repos/$UPSTREAM/commits?path=npm-packages/convex/package.json&per_page=50" \
+              --jq '.[] | [.sha, .commit.committer.date,
+                    (.commit.message | split("\n")[0])] | @tsv' > npm-commits.tsv
+
+            cutoff="$(date -u -d "-${MIN_AGE_DAYS} days" +%Y-%m-%dT%H:%M:%SZ)"
+            if [ -n "$INPUT_VERSION" ]; then
+              [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+                || { echo "::error::version must look like X.Y.Z"; exit 1; }
+              # An explicit version is an explicit ask — no fallback to others.
+              awk -F'\t' -v v="$INPUT_VERSION" \
+                '$3 ~ ("^npm release version " v "( |$)") { print; exit }' npm-commits.tsv > npm-picks.tsv
+              [ -s npm-picks.tsv ] || { echo "::error::no 'npm release version $INPUT_VERSION' commit found in the newest 50 package.json commits"; exit 1; }
+            else
+              # Eligible npm releases, newest first, at least MIN_AGE_DAYS old
+              # (ISO-8601 Z strings compare lexicographically). Up to 3: the
+              # newest one's anchor images may not be on GHCR yet (pushes lag),
+              # in which case the previous version is the right target.
+              awk -F'\t' -v c="$cutoff" \
+                '$3 ~ /^npm release version [0-9]+\.[0-9]+\.[0-9]+/ && $2 <= c { print; n++ } n == 3 { exit }' \
+                npm-commits.tsv > npm-picks.tsv
+              [ -s npm-picks.tsv ] || skip "no npm release at least $MIN_AGE_DAYS days old found; nothing to do"
+            fi
+
+            while IFS=$'\t' read -r npm_sha npm_date subject; do
+              ver="$(printf '%s' "$subject" | sed -E 's/^npm release version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+              [[ "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::could not parse version from: $subject"; exit 1; }
+              echo "trying npm $ver = $npm_sha ($npm_date)"
+
+              # Anchor candidates: releases published at/after the npm commit,
+              # OLDEST first. The list is not ancestry-ordered, so each
+              # candidate is containment-checked inside try_release.
+              attempts=0
+              while IFS= read -r cand; do
+                [ -n "$cand" ] || continue
+                attempts=$((attempts + 1))
+                [ "$attempts" -le 25 ] || break
+                if try_release "$cand" "$npm_sha"; then break; fi
+              done < <(awk -F'\t' -v d="$npm_date" '$2 >= d { a[++n] = $1 } END { for (i = n; i >= 1; i--) print a[i] }' releases.tsv)
+              [ -z "$tag" ] || break
+              echo "npm $ver has no image-bearing anchor release yet (GHCR pushes lag); trying the previous version"
+              ver=''
+            done < npm-picks.tsv
+          fi
+          [ -n "$tag" ] || { echo "::error::no usable anchor found — GHCR image pushes may be lagging badly; retry later, or pass an explicit release_tag whose images exist"; exit 1; }
+          [[ "$bdig" =~ ^[0-9a-f]{64}$ ]] && [[ "$ddig" =~ ^[0-9a-f]{64}$ ]] \
+            || { echo "::error::digest resolution returned an unexpected shape"; exit 1; }
+          echo "target: $tag ($new)"
+
+          if [ -n "$ver" ]; then
+            branch="convex-repin/npm-$ver"
+          else
+            branch="convex-repin/$tag"
+          fi
+
+          # Dedupe: a PR already open on this exact branch has nothing to
+          # refresh (digests for a fixed tag are immutable).
+          same="$(gh pr list --state open --head "$branch" --json number --jq '.[0].number // empty')"
+          [ -z "$same" ] || skip "PR #$same is already open on $branch; nothing to do"
+
+          old="$(bash scripts/convex-repin.sh "$new" "$bdig" "$ddig" "$tag" ${ver:+"$ver"})"
+          git diff --quiet docker-compose.stack.yml \
+            && skip "already pinned to $tag; nothing to do"
+
+          old_tag="$(awk -F'\t' -v s="${old:0:7}" '$1 ~ ("-" s "$") { print $1; exit }' releases.tsv)"
+          # A pin older than the newest 100 releases still compares by raw sha.
+          [ -n "$old_tag" ] || old_tag="$old"
+
+          {
+            echo "proceed=true"
+            echo "version=$ver"
+            echo "tag=$tag"
+            echo "new=$new"
+            echo "old=$old"
+            echo "old_tag=$old_tag"
+            echo "branch=$branch"
+            echo "ahead_by=$ahead_by"
+          } >> "$GITHUB_OUTPUT"
+
+      # Self-verification on the exact commit the PR will carry. This stands in
+      # for PR CI, which will NOT run (GITHUB_TOKEN-opened PR).
+      - uses: oven-sh/setup-bun@v2
+        if: steps.prepare.outputs.proceed == 'true'
+        with:
+          bun-version-file: package.json
+      - if: steps.prepare.outputs.proceed == 'true'
+        run: bun install --frozen-lockfile
+      - if: steps.prepare.outputs.proceed == 'true'
+        run: bun run test
+      - if: steps.prepare.outputs.proceed == 'true'
+        run: bunx prettier --check docker-compose.stack.yml
+
+      - name: Upload the diff (dry run)
+        if: steps.prepare.outputs.proceed == 'true' && env.DRY_RUN == 'true'
+        run: git diff docker-compose.stack.yml > repin.diff
+      - uses: actions/upload-artifact@v4
+        if: steps.prepare.outputs.proceed == 'true' && env.DRY_RUN == 'true'
+        with:
+          name: repin-diff
+          path: repin.diff
+
+      - name: Open the re-pin PR
+        if: steps.prepare.outputs.proceed == 'true' && env.DRY_RUN != 'true'
+        env:
+          VER: ${{ steps.prepare.outputs.version }}
+          TAG: ${{ steps.prepare.outputs.tag }}
+          NEW: ${{ steps.prepare.outputs.new }}
+          OLD: ${{ steps.prepare.outputs.old }}
+          OLD_TAG: ${{ steps.prepare.outputs.old_tag }}
+          BRANCH: ${{ steps.prepare.outputs.branch }}
+          AHEAD_BY: ${{ steps.prepare.outputs.ahead_by }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$VER" ]; then
+            title="chore(docker): re-pin Convex self-hosted to the npm $VER anchor ($TAG)"
+            what="the **npm $VER** anchor build"
+            notes="Release notes: [ship.convex.dev](https://ship.convex.dev/) · [npm CHANGELOG](https://github.com/$UPSTREAM/blob/main/npm-packages/convex/CHANGELOG.md) (§ $VER). The anchor is $AHEAD_BY commit(s) past the npm release commit."
+          else
+            title="chore(docker): re-pin Convex self-hosted to $TAG"
+            what="release \`$TAG\` (raw pin — NOT an npm anchor; escape-hatch dispatch)"
+            notes="No npm release notes apply to a raw pin; the compare link below is the only changelog."
+          fi
+
+          compare="https://github.com/$UPSTREAM/compare/$OLD_TAG...$TAG"
+
+          # Heuristic scan of commit subjects for operator-relevant keywords.
+          # The compare API caps at 250 commits; detect and say so rather than
+          # presenting a silently partial list as complete.
+          scan_note=''
+          total="$(gh api "/repos/$UPSTREAM/compare/$OLD_TAG...$TAG" --jq .total_commits || echo '')"
+          listed="$(gh api "/repos/$UPSTREAM/compare/$OLD_TAG...$TAG" \
+            --jq '.commits[].commit.message | split("\n")[0]' 2>/dev/null | tee subjects.txt | wc -l | tr -d ' ')"
+          if [ -n "$total" ] && [ "$total" != "$listed" ]; then
+            scan_note="⚠️ The compare API truncated at $listed of $total commits — the scan below is PARTIAL. Read the [web compare view]($compare)."
+          fi
+          scan="$(grep -iE 'migrat|breaking|rename|remove|deprecat|env var|_ENV' subjects.txt | head -20 || true)"
+          [ -n "$scan" ] || scan='(no commit subjects matched the keyword scan)'
+
+          prod_date="$(date -u -d '+3 days' +%Y-%m-%d)"
+
+          cat > body.md <<EOF
+          Re-pins \`convex-backend\` / \`convex-dashboard\` (and the \`keygen\` one-shot) to $what.
+
+          | | release | commit |
+          |---|---|---|
+          | old | \`$OLD_TAG\` | \`$OLD\` |
+          | new | \`$TAG\` | \`$NEW\` |
+
+          $notes
+
+          **Backend changelog**: $compare — release-to-release, deliberately not
+          \`...HEAD\`. The npm release notes cover the CLI/client surface; this
+          compare is the only changelog for backend internals.
+
+          $scan_note
+
+          Commit subjects matching \`migrat|breaking|rename|remove|deprecat|env\` (worth a second look, not a verdict):
+
+          \`\`\`
+          $scan
+          \`\`\`
+
+          ### Operator checklist ([runbook](https://github.com/${{ github.repository }}/blob/main/docs/beta-deploy.md#upgrading-the-convex-backend-image-re-pin))
+
+          - [ ] Skim the compare for env-var renames / migration notes
+          - [ ] Lockfile \`convex\` ≤ the anchored version (land any open Dependabot \`convex\` PR in this window)
+          - [ ] \`backup\` service healthy (fresh heartbeat) on beta
+          - [ ] Pre-upgrade \`convex export\` + env capture taken on beta
+          - [ ] Merge
+          - [ ] Deploy beta (\`pull\` + \`up -d --force-recreate backend dashboard keygen deployer\`), watch for \`MigrationComplete(N)\` — do NOT restart mid-migration
+          - [ ] Beta verified: \`/readyz\` 200, deployer \`[deploy] OK\`, dashboard loads, next backup cycle green
+          - [ ] Soaked ≥3 days on beta — earliest prod deploy: **$prod_date**
+          - [ ] Prod: fresh pre-flight (its OWN export), deploy, verify
+
+          > **CI note:** this PR was opened by \`GITHUB_TOKEN\`, so pull-request CI
+          > did not trigger. The workflow ran the FULL test suite (including
+          > \`convex/deployPins.test.ts\`) and prettier on this exact commit — see
+          > the [run log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          > To kick full PR CI anyway: close and reopen the PR.
+          >
+          > A newer re-pin PR automatically closes this one ("superseded"); don't
+          > push fixups onto this branch expecting them to survive that.
+
+          _Opened automatically by \`.github/workflows/convex-repin.yml\`._
+          EOF
+          sed -i 's/^          //' body.md
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$BRANCH"
+          git add docker-compose.stack.yml
+          git commit -m "$title"
+          git push origin "$BRANCH"
+
+          new_pr_url="$(gh pr create --base main --head "$BRANCH" --title "$title" \
+            --body-file body.md --label dependencies --label docker)"
+          echo "opened $new_pr_url"
+
+          # Exactly one open re-pin PR at a time: an older one is strictly
+          # dominated by this one.
+          gh pr list --state open --json number,headRefName \
+            --jq ".[] | select(.headRefName | startswith(\"convex-repin/\")) | select(.headRefName != \"$BRANCH\") | .number" \
+            | while read -r n; do
+                gh pr close "$n" --delete-branch \
+                  --comment "Superseded by the newer re-pin PR ($title)."
+                echo "closed superseded PR #$n"
+              done

--- a/convex/deployPins.test.ts
+++ b/convex/deployPins.test.ts
@@ -272,4 +272,32 @@ describe('cross-file image pins', () => {
       expect(digests.size, `${image} is pinned to ${digests.size} different digests`).toBe(1);
     }
   });
+
+  test('the compose comment names the release the Convex images are pinned to', () => {
+    // The `backend` service comment carries `<sha7> = precompiled-<date>-<sha7>`
+    // (optionally suffixed `(the npm X.Y.Z anchor)` — written by every
+    // scripts/convex-repin.sh run; pins predating the anchor policy lack it).
+    // scripts/convex-repin.sh rewrites that comment with a pattern
+    // substitution, and a reflow of the comment block would make the rewrite
+    // silently no-op — the script's own count assertion catches that at repin
+    // time, and this test catches a comment that already drifted from the pin.
+    const comment = stack.match(
+      /\b([0-9a-f]{7}) = (precompiled-\d{4}-\d{2}-\d{2}-\1)(?: \(the npm \d+\.\d+\.\d+ anchor\))?/,
+    );
+    expect(
+      comment,
+      'the backend service comment must name the pinned release as ' +
+        '`<sha7> = precompiled-<date>-<sha7>` — scripts/convex-repin.sh rewrites ' +
+        'exactly that shape, and convex-release-watch.yml relies on the tag being real.',
+    ).not.toBeNull();
+
+    const pinnedSha = stack.match(/image:\s*ghcr\.io\/get-convex\/convex-backend:([0-9a-f]{40})@/);
+    expect(pinnedSha).not.toBeNull();
+    expect(
+      comment![1],
+      `the comment says the pin is ${comment![1]} but the images are pinned to ` +
+        `${pinnedSha![1].slice(0, 7)} — the release-name comment drifted from the actual pin ` +
+        '(a hand-edit skipped scripts/convex-repin.sh, or the script rewrite broke).',
+    ).toBe(pinnedSha![1].slice(0, 7));
+  });
 });

--- a/docker-compose.stack.yml
+++ b/docker-compose.stack.yml
@@ -46,9 +46,13 @@ services:
     # tell you what you are on.
     #
     # Dependabot CANNOT bump these (a 40-hex tag fails its NAME_WITH_VERSION
-    # regex, so it is not version-comparable). That is the deliberate trade for
-    # the tag, and .github/workflows/convex-release-watch.yml replaces the
-    # notification — it files an issue when newer releases exist.
+    # regex, so it is not version-comparable). Instead,
+    # .github/workflows/convex-repin.yml opens a monthly re-pin PR anchored to
+    # the newest ship.convex.dev (npm) release, scripts/convex-repin.sh rewrites
+    # the three refs + the release-name comment above (which
+    # convex/deployPins.test.ts asserts matches the pin — don't hand-edit one
+    # without the other), and .github/workflows/convex-release-watch.yml files
+    # an issue only if that flow stalls.
     #
     # Backend and dashboard MUST share this tag: "Make sure to use the same
     # version of convex-backend and convex-dashboard. Different versions are not
@@ -57,6 +61,7 @@ services:
     #
     # Upgrading runs in-place DB migrations. Take an export first, then watch for
     # `MigrationComplete(N)` in the backend log (self-hosted/advanced/upgrading.md).
+    # Full procedure: docs/beta-deploy.md § Upgrading the Convex backend.
     image: ghcr.io/get-convex/convex-backend:1bd6910bc0b4066a918809912670d42afc8fdfb0@sha256:104b8bc70e29b31fa4a57551596090bfc9eedc3d1f27fd4b8cd8d0e782b9b070
     pids_limit: 512
     restart: unless-stopped

--- a/docs/beta-deploy.md
+++ b/docs/beta-deploy.md
@@ -340,7 +340,9 @@ See `docs/threat-model-cdn-blinding.md`.
   digests 2026-07-07 (valkey 8→9, transparent — Cap uses it as a plain
   Redis-compatible store). Re-pin on intentional upgrades:
   `docker buildx imagetools inspect <image:tag>` (keep the backend/keygen pair
-  and the postgres compose/backup-Dockerfile pair matched).
+  and the postgres compose/backup-Dockerfile pair matched). For the Convex
+  images specifically, use the monthly flow instead — see
+  § Upgrading the Convex backend below.
 - **Privacy defaults.** The stack does not persist client IPs anywhere by
   default — Caddy access logs are explicitly discarded, the backend's request
   log is silenced, and Cap is configured not to surface a peer IP. The full
@@ -539,6 +541,119 @@ Run a **restore drill** before launch and periodically after:
 asserts core-table row counts, and drops it (set `AGE_KEY_FILE` for encrypted
 dumps). A backup that has never been restored is not a backup.
 
+### Upgrading the Convex backend (image re-pin)
+
+**Policy.** The `convex-backend`/`convex-dashboard`/`keygen` pins in
+`docker-compose.stack.yml` are bumped **monthly**:
+`.github/workflows/convex-repin.yml` opens a PR on the first Monday, anchored
+to the newest version announced on [ship.convex.dev](https://ship.convex.dev/)
+(the `convex` npm releases) that is **at least 7 days old**. An "anchor" is the
+first precompiled release whose commit contains the `npm release version X.Y.Z`
+commit — Convex publishes no notes for individual backend builds, so anchoring
+gives every bump real release notes and keeps the backend in lockstep with the
+Dependabot-managed `convex` CLI in `bun.lock` (land any open Dependabot
+`convex` PR in the same window; the deployer's pinned CLI is what pushes to the
+upgraded backend). Nothing auto-merges and nothing auto-deploys. A new pin
+soaks on **beta ≥3 days** before prod deploys the same commit.
+
+_Security exception:_ a fix for an actively exploited backend issue jumps the
+queue — `gh workflow run convex-repin.yml -f version=X.Y.Z` (or
+`-f release_tag=precompiled-…` when the fix is not in any npm release yet), and
+the soak collapses to "beta is green" at operator judgment.
+
+_Escalation:_ `convex-release-watch.yml` files an issue only when the pinned
+release is older than its staleness threshold — i.e. only when this flow has
+stalled. Being some releases behind is normal; Convex ships near-daily.
+
+Caveat to keep in mind while reviewing the PR: the npm release notes describe
+the CLI/client surface. The PR's release-to-release compare link is the
+**only** changelog for backend internals — skim it for renamed or
+newly-required backend env vars (the `backend` service sets a specific list in
+the compose file; `RUST_LOG=info,convex-cloud-http=warn` is the fragile one),
+Postgres schema changes, and changes to `generate_admin_key.sh` (the `keygen`
+one-shot parses its output).
+
+**Pre-upgrade checklist** (run on beta first; repeat on prod with `.env.prod`
+before the prod deploy — the beta export is not a prod backup):
+
+1. `backup` service healthy, heartbeat fresh:
+
+   ```sh
+   docker compose -f docker-compose.stack.yml --env-file .env.beta ps backup
+   docker compose -f docker-compose.stack.yml --env-file .env.beta exec backup ls -l /backups/.heartbeat
+   ```
+
+2. Take an on-demand snapshot export through the deployer container (the
+   "One-off functions" recipe with a host mount; `--no-deps` is right — the
+   backend is already running on the OLD image, which is exactly the state you
+   want the export to capture):
+
+   ```sh
+   mkdir -p snapshots
+   docker compose -f docker-compose.stack.yml --env-file .env.beta \
+     run --rm --no-deps -v "$PWD/snapshots:/snapshots" --entrypoint bash deployer -c '
+       export CONVEX_SELF_HOSTED_ADMIN_KEY="$(grep "|" /keys/admin_key | tail -n1 | tr -d "[:space:]")" \
+       && bunx convex export --path "/snapshots/pre-upgrade-$(date -u +%Y%m%dT%H%M%SZ).zip"'
+   ```
+
+3. Capture the deployment env alongside it (encrypted, same recipient as the
+   dumps — see § Backups & restore):
+
+   ```sh
+   docker compose -f docker-compose.stack.yml --env-file .env.beta \
+     run --rm --no-deps --entrypoint bash deployer -c '
+       export CONVEX_SELF_HOSTED_ADMIN_KEY="$(grep "|" /keys/admin_key | tail -n1 | tr -d "[:space:]")" \
+       && bunx convex env list' \
+     | age -r "$BACKUP_AGE_PUBLIC_KEY" -o "convex-env-$(date -u +%Y%m%d).txt.age"
+   ```
+
+   Note the export does **not** cover the backend's `data` volume (file blobs)
+   — see the coverage notes in § Backups & restore.
+
+**Deploy.** Different from the §6 recipe (which recreates `web deployer` only)
+— an image re-pin must recreate the three Convex containers:
+
+```sh
+git pull
+docker compose -f docker-compose.stack.yml --env-file .env.beta pull backend dashboard keygen
+docker compose -f docker-compose.stack.yml --env-file .env.beta \
+  up -d --force-recreate backend dashboard keygen deployer
+```
+
+`keygen` re-runs on the new binary (its `generate_admin_key.sh` ships in the
+backend image); the deployer re-push is idempotent insurance. Backend +
+dashboard restart, so there is a short API gap — fine on beta, announce it for
+prod.
+
+**Verify:**
+
+```sh
+docker compose -f docker-compose.stack.yml --env-file .env.beta logs backend | grep -i migration
+# expect MigrationComplete(N); a big jump may run several and take a while —
+# do NOT restart the backend mid-migration.
+docker compose -f docker-compose.stack.yml --env-file .env.beta logs --tail=40 deployer   # [deploy] OK
+curl -fsS https://beta.freesocks.org/readyz
+docker compose -f docker-compose.stack.yml --env-file .env.beta ps   # nothing unhealthy/restarting
+```
+
+Plus: the dashboard loads over the SSH tunnel, and the next backup cycle goes
+green (the sidecar talks to Postgres, not the backend, but a green cycle after
+the upgrade is the cheapest proof nothing wedged).
+
+**Prod promotion.** Same commit, ≥3 days later: rerun the full pre-upgrade
+checklist against `.env.prod` (including prod's own export), deploy, verify.
+
+**Rollback truth.** Re-pinning back to the old sha is **not** a rollback once
+migrations have run: upgrades apply in-place DB migrations, Convex documents no
+downgrade path, and an older binary against a migrated database is undefined
+behavior. The only real rollback is restore-from-backup — `bunx convex import
+--replace-all` of the pre-upgrade export (via the same deployer recipe), or the
+pg_dump restore above. This is why the export step is mandatory, not advisory.
+
+One more drift hazard: the **dev stack** (`docker-compose.yml`) deliberately
+runs `:latest`, so local dev can be _ahead_ of beta/prod — behavior that works
+locally may come from a build the stack does not have yet.
+
 ### Rollback (A4)
 
 Deploys are idempotent and the contract changes are kept additive (backend-first
@@ -553,6 +668,9 @@ is safe). To roll back:
    (`docker compose ... up -d --build web`) — it bakes the SPA from that checkout.
 3. **Schema:** Convex applies schema on deploy; a rollback that drops a field
    only affects new writes. Restore from a backup only if data was corrupted.
+4. **Convex backend image:** there is no image rollback once its in-place DB
+   migrations have run — restore the pre-upgrade export instead. See
+   § Upgrading the Convex backend above.
 
 ### Incident runbook (quick reference)
 

--- a/docs/convex-self-hosting.md
+++ b/docs/convex-self-hosting.md
@@ -366,25 +366,31 @@ bunx convex import --replace-all snapshot.zip
 > so export first and watch for `MigrationComplete(N)`.
 >
 > Dependabot cannot see past a git-sha tag, so
-> `.github/workflows/convex-release-watch.yml` files an issue when the pin falls
-> behind, and `convex/deployPins.test.ts` fails the build if the two images
-> drift apart or someone re-floats one to `:latest`.
+> `.github/workflows/convex-repin.yml` opens a monthly re-pin PR (anchored to
+> the newest ship.convex.dev release), `convex-release-watch.yml` files an
+> issue only if that flow stalls, and `convex/deployPins.test.ts` fails the
+> build if the two images drift apart or someone re-floats one to `:latest`.
+> The full upgrade procedure (export-first, beta soak, rollback truth) lives in
+> `docs/beta-deploy.md` § Upgrading the Convex backend.
 
 ### Three Convex versions, only one of them semver
 
 Easy to conflate, so worth stating plainly:
 
-| what                        | where                       | versioning                           | tracked by                   |
-| --------------------------- | --------------------------- | ------------------------------------ | ---------------------------- |
-| `convex-backend` image      | `docker-compose.stack.yml`  | 40-char git sha = one GitHub release | `convex-release-watch.yml`   |
-| `convex-dashboard` image    | `docker-compose.stack.yml`  | same git sha, must match the backend | `deployPins.test.ts`         |
-| `convex` npm (client + CLI) | `package.json` / `bun.lock` | real semver (`1.44.0`)               | Dependabot (`bun` ecosystem) |
+| what                        | where                       | versioning                           | tracked by                     |
+| --------------------------- | --------------------------- | ------------------------------------ | ------------------------------ |
+| `convex-backend` image      | `docker-compose.stack.yml`  | 40-char git sha = one GitHub release | `convex-repin.yml` (+ watcher) |
+| `convex-dashboard` image    | `docker-compose.stack.yml`  | same git sha, must match the backend | `deployPins.test.ts`           |
+| `convex` npm (client + CLI) | `package.json` / `bun.lock` | real semver (`1.44.0`)               | Dependabot (`bun` ecosystem)   |
 
 The versions on [ship.convex.dev](https://ship.convex.dev/) are the **npm
 package**, not the backend image — there is no `convex-backend:v1.44.0` to pin
 to, and there never has been. The images carry only per-commit git shas plus
 `latest` (the curated `self-hosted-release-<date>-<sha>` git tags stopped in
-2025-09).
+2025-09). The monthly re-pin bridges the two: it pins the backend to the
+**anchor** of an npm release — the first precompiled build whose commit
+contains the `npm release version X.Y.Z` commit — so every image bump still
+maps to a named, release-noted version.
 
 The npm half is not cosmetic: `docker/deploy-entrypoint.sh` runs `bunx convex …`
 from this repo's lockfile, so the pinned CLI is what pushes functions, schema and

--- a/scripts/convex-repin.sh
+++ b/scripts/convex-repin.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Re-pin the Convex self-hosted images in docker-compose.stack.yml.
+#
+#   scripts/convex-repin.sh <new-40hex-sha> <backend-digest> <dashboard-digest> \
+#     <release-tag> [npm-version]
+#
+# Rewrites, in place:
+#   - the two `convex-backend` refs (the `backend` service + the one-shot
+#     `keygen`, which reuses the backend image),
+#   - the one `convex-dashboard` ref,
+#   - the release-name comment on the `backend` service, which
+#     convex/deployPins.test.ts asserts matches the pinned tag.
+# Prints the OLD pinned sha on stdout (the caller builds the compare link from
+# it). Exits 0 with a notice when the file already pins <new-40hex-sha>.
+#
+# <npm-version> (e.g. 1.45.0) names the ship.convex.dev release this build
+# anchors; when given, the comment gains "(the npm <version> anchor)". Omit it
+# only for the raw-release escape hatch (a pin that is not an npm anchor).
+#
+# Digests are the bare 64-hex value (no "sha256:" prefix) — the multi-arch
+# INDEX digest, i.e. `docker buildx imagetools inspect <image>:<sha>` →
+# Manifest.Digest, NOT a per-platform manifest digest.
+#
+# perl -pi, not sed -i: BSD sed (darwin) takes an argument after -i and GNU sed
+# does not, and this script must run identically on the operator's Mac and the
+# ubuntu runner. Each substitution's replacement count is asserted — perl and
+# sed both exit 0 on zero matches, which would otherwise leave a silently
+# half-rewritten compose file. All edits land on a temp copy first, so a failed
+# assertion leaves the real file untouched.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <new-40hex-sha> <backend-digest> <dashboard-digest> <release-tag> [npm-version]" >&2
+  exit 2
+}
+
+[ "$#" -ge 4 ] && [ "$#" -le 5 ] || usage
+
+NEW="$1"
+BDIG="$2"
+DDIG="$3"
+TAG="$4"
+VER="${5:-}"
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+FILE="$repo_root/docker-compose.stack.yml"
+
+[[ "$NEW" =~ ^[0-9a-f]{40}$ ]] || {
+  echo "error: new sha must be 40 lowercase hex chars, got: $NEW" >&2
+  exit 2
+}
+[[ "$BDIG" =~ ^[0-9a-f]{64}$ ]] || {
+  echo "error: backend digest must be 64 bare hex chars (no sha256: prefix), got: $BDIG" >&2
+  exit 2
+}
+[[ "$DDIG" =~ ^[0-9a-f]{64}$ ]] || {
+  echo "error: dashboard digest must be 64 bare hex chars (no sha256: prefix), got: $DDIG" >&2
+  exit 2
+}
+[[ "$TAG" =~ ^precompiled-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9a-f]{7}$ ]] || {
+  echo "error: release tag must look like precompiled-YYYY-MM-DD-<sha7>, got: $TAG" >&2
+  exit 2
+}
+[ -z "$VER" ] || [[ "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || {
+  echo "error: npm version must look like X.Y.Z, got: $VER" >&2
+  exit 2
+}
+NEW7="${NEW:0:7}"
+[ "${TAG##*-}" = "$NEW7" ] || {
+  echo "error: release tag suffix (${TAG##*-}) does not match the new sha ($NEW7)" >&2
+  exit 2
+}
+
+OLD="$(grep -oE 'ghcr\.io/get-convex/convex-backend:[0-9a-f]{40}' "$FILE" | head -1 | cut -d: -f2)"
+[ -n "$OLD" ] || {
+  echo "error: no git-sha-tagged convex-backend pin found in $FILE" >&2
+  exit 1
+}
+
+if [ "$OLD" = "$NEW" ]; then
+  echo "already pinned to $NEW7 ($TAG); nothing to do" >&2
+  echo "$OLD"
+  exit 0
+fi
+
+if [ -n "$VER" ]; then
+  COMMENT="$NEW7 = $TAG (the npm $VER anchor)"
+else
+  COMMENT="$NEW7 = $TAG"
+fi
+
+tmp="$(mktemp "$FILE.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+cp "$FILE" "$tmp"
+
+# Each perl pass prints its replacement count on stderr; -pi sends the rewritten
+# lines to the file, so stderr is free for the count.
+substitute() { # <expected-count> <label> <perl-expression>
+  local expected="$1" label="$2" expr="$3" got
+  got="$(perl -pi -e "$expr" "$tmp" 2>&1)"
+  if [ "$got" != "$expected" ]; then
+    echo "error: expected $expected $label replacement(s), made ${got:-0} — docker-compose.stack.yml no longer matches the shape this script expects; fix the script or the file" >&2
+    exit 1
+  fi
+}
+
+export NEW BDIG DDIG COMMENT
+substitute 2 'convex-backend ref' \
+  '$c += s{(image:\s*ghcr\.io/get-convex/convex-backend:)[0-9a-f]{40}\@sha256:[0-9a-f]{64}}{$1$ENV{NEW}\@sha256:$ENV{BDIG}}g; END { print STDERR $c // 0 }'
+substitute 1 'convex-dashboard ref' \
+  '$c += s{(image:\s*ghcr\.io/get-convex/convex-dashboard:)[0-9a-f]{40}\@sha256:[0-9a-f]{64}}{$1$ENV{NEW}\@sha256:$ENV{DDIG}}g; END { print STDERR $c // 0 }'
+substitute 1 'release-name comment' \
+  '$c += s{\b[0-9a-f]{7} = precompiled-\d{4}-\d{2}-\d{2}-[0-9a-f]{7}(?: \(the npm \d+\.\d+\.\d+ anchor\))?}{$ENV{COMMENT}}g; END { print STDERR $c // 0 }'
+
+mv "$tmp" "$FILE"
+trap - EXIT
+
+echo "re-pinned ${OLD:0:7} -> $NEW7 ($TAG)" >&2
+echo "$OLD"


### PR DESCRIPTION
Establishes the Convex backend upgrade policy + automation planned from issue #28 (the pin is 7 weeks / 100+ releases behind with no cadence, no tooling, and no documented rollback).

## The policy
- **Monthly**: on the first Monday, `.github/workflows/convex-repin.yml` opens a PR re-pinning backend/dashboard/keygen to the **anchor** of the newest [ship.convex.dev](https://ship.convex.dev/) version at least 7 days old. An anchor = the first precompiled release whose commit **contains** the `npm release version X.Y.Z` commit *and* whose images exist on GHCR. Nothing auto-merges; nothing auto-deploys.
- **Beta soak ≥3 days** before prod deploys the same commit.
- **Export-first is mandatory**: re-pinning back after in-place migrations is NOT a rollback — restore-from-export is. Now stated in the docs (it was nowhere).
- **Escalation**: the watcher files an issue only when the pin is >49 days old (= the flow stalled), instead of today's permanently-open "behind upstream" issue.

## Verified live before opening this PR
- `scripts/convex-repin.sh` exercised against the real compose file: exactly 4 lines changed, idempotent second run, counted assertions trip on a mangled file and leave it untouched (temp-copy design).
- The workflow's selection pipeline rehearsed end-to-end locally with real API + GHCR calls: picked npm 1.44.0 (1.45.0 is under the age gate), fell forward past `precompiled-2026-08-13-d92fc05` (release exists, **image doesn't** — GHCR pushes lag releases; the newest image is 6 days behind) to `precompiled-2026-08-14-0dda4d6`, resolved real index digests, rewrote the compose, and passed `deployPins.test.ts` + prettier on the result.
- Two upstream surprises found and handled: **every** precompiled release is flagged `prerelease: true` (the filter keys off the tag shape instead), and only ~half the releases ever get GHCR images (the selection falls back to the previous npm version when the newest has none).
- All workflow `run:` blocks shellchecked; full suite 1202 tests green (including the new pin-comment drift lock).

## Notes for after merge
- Scheduled + `workflow_dispatch` runs only work once this is on `main`.
- Re-pin PRs are opened with the default `GITHUB_TOKEN` (deliberate: no new secrets), so PR CI won't fire on them — the workflow runs the **full test suite** on the exact commit instead, and the PR body says how to kick CI (close/reopen).
- The catch-up bump (closes #28) is the first real exercise: dispatch with `dry_run=true`, inspect, then `dry_run=false`. Today it would anchor **1.44.0** (`precompiled-2026-08-14-0dda4d6`); 1.45.0 has no image-bearing anchor on GHCR yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)