### PR TITLE
feat(seo): serve sitemap.xml + robots.txt, host-templated through Caddy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -243,6 +243,17 @@
 		templates {
 			mime text/html
 		}
+		# Expand {{placeholder "http.request.host"}} in robots.txt + sitemap.xml
+		# so their canonical URLs track the deployment host (beta vs prod) with a
+		# single committed file. Deliberately a SEPARATE, path-scoped instance
+		# rather than widening the block above: template execution on all
+		# text/plain would 500 on any future .txt that happens to contain `{{`.
+		# (.xml MIME varies by system table — match both text/xml and
+		# application/xml.)
+		@seoFiles path /robots.txt /sitemap.xml
+		templates @seoFiles {
+			mime text/plain text/xml application/xml
+		}
 		file_server
 	}
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,13 @@
+# Served through Caddy's `templates` directive (see the @seoFiles block in the
+# Caddyfile): the {{placeholder "http.request.host"}} token expands to the
+# request's Host, so the Sitemap URL stays same-host on every deployment.
+# The Vite dev server serves this file raw; it is a production artifact.
+
+User-agent: *
+Disallow: /account
+Disallow: /login
+Disallow: /admin
+Disallow: /api/
+Disallow: /cap/
+
+Sitemap: https://{{placeholder "http.request.host"}}/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,7 +7,7 @@ User-agent: *
 Disallow: /account
 Disallow: /login
 Disallow: /admin
-Disallow: /api/
-Disallow: /cap/
+Disallow: /api
+Disallow: /cap
 
 Sitemap: https://{{placeholder "http.request.host"}}/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,6 +7,13 @@ User-agent: *
 Disallow: /account
 Disallow: /login
 Disallow: /admin
+# Crawler renderers (e.g. Googlebot's headless Chromium) honor robots.txt for
+# the SPA's runtime fetches, so the two public read-only GETs that hydrate the
+# indexable pages stay allowed (longest-match wins over the /api disallow) —
+# without them /status renders as an empty skeleton in the index. Both are
+# per-IP rate-limited (status.fetch / config.fetch policies).
+Allow: /api/v1/status
+Allow: /api/v1/config
 Disallow: /api
 Disallow: /cap
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Served through Caddy's `templates` directive (see the @seoFiles block in the
+  Caddyfile): each {{placeholder "http.request.host"}} token expands to the
+  request's Host, so the same file yields same-host canonical URLs on every
+  deployment (beta.freesocks.org and freesocks.org alike). The scheme is
+  hardcoded https because the public origin is always TLS even when Caddy
+  itself serves plain HTTP behind a terminating edge (CADDY_SCHEME=http).
+  The Vite dev server serves this file raw (placeholders unexpanded); it is a
+  production artifact.
+
+  Public, indexable SPA routes only. Auth-gated and non-content surfaces
+  (/account, /login, /admin, /api, /cap) are excluded here and disallowed in
+  robots.txt. Adding a public member-facing route means adding a <url> entry
+  here (pinned by src/client/lib/sitemap.test.ts) as well as a line in the
+  telemetry ROUTE_ALLOWLIST (convex/lib/umami.ts).
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://{{placeholder "http.request.host"}}/</loc>
+  </url>
+  <url>
+    <loc>https://{{placeholder "http.request.host"}}/get-account</loc>
+  </url>
+  <url>
+    <loc>https://{{placeholder "http.request.host"}}/status</loc>
+  </url>
+</urlset>

--- a/src/client/lib/sitemap.test.ts
+++ b/src/client/lib/sitemap.test.ts
@@ -26,7 +26,9 @@ const HOST = '{{placeholder "http.request.host"}}';
 const NON_INDEXABLE = ['/account', '/login'];
 
 // The actual route switch: every `router.pathname === '/x'` literal.
-const routerRoutes = [...appSvelte.matchAll(/router\.pathname === '([^']+)'/g)].map((m) => m[1]);
+const routerRoutes = [...appSvelte.matchAll(/router\.pathname === '([^']+)'/g)].map(
+  (m) => m[1] ?? '',
+);
 const indexableRoutes = routerRoutes.filter((route) => !NON_INDEXABLE.includes(route));
 
 describe('sitemap.xml', () => {
@@ -70,7 +72,7 @@ describe('robots.txt', () => {
     }
     // No disallow may prefix-shadow an indexable route (e.g. a hypothetical
     // `Disallow: /get` would block the public /get-account).
-    const disallows = [...robots.matchAll(/^Disallow: (\S+)/gm)].map((m) => m[1]);
+    const disallows = [...robots.matchAll(/^Disallow: (\S+)/gm)].map((m) => m[1] ?? '');
     for (const route of indexableRoutes.filter((r) => r !== '/')) {
       expect(disallows.some((d) => route.startsWith(d))).toBe(false);
     }

--- a/src/client/lib/sitemap.test.ts
+++ b/src/client/lib/sitemap.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
 //
 // Pins public/sitemap.xml + public/robots.txt to the SPA's public route set and
-// to the Caddy templating that expands their host placeholders. Adding or
-// removing a public member-facing route (App.svelte's route switch) must update
-// PUBLIC_ROUTES here alongside the sitemap itself (and the telemetry
-// ROUTE_ALLOWLIST in convex/lib/umami.ts).
+// to the Caddy templating that expands their host placeholders. The expected
+// route list is DERIVED from App.svelte's route switch, so adding or removing a
+// route there fails this test until the sitemap (or NON_INDEXABLE below) is
+// updated too — the same must-stay-in-sync convention as the telemetry
+// ROUTE_ALLOWLIST in convex/lib/umami.ts.
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, test } from 'vitest';
@@ -13,16 +14,29 @@ const root = resolve(__dirname, '../../..');
 const sitemap = readFileSync(resolve(root, 'public/sitemap.xml'), 'utf8');
 const robots = readFileSync(resolve(root, 'public/robots.txt'), 'utf8');
 const caddyfile = readFileSync(resolve(root, 'Caddyfile'), 'utf8');
+const appSvelte = readFileSync(resolve(root, 'src/client/App.svelte'), 'utf8');
 
-// Caddy expands this per request; the committed file must carry it verbatim so
+// Caddy expands this per request; the committed files must carry it verbatim so
 // every deployment serves same-host canonical URLs.
 const HOST = '{{placeholder "http.request.host"}}';
 
-// The indexable public routes. Auth-gated and non-content surfaces (/account,
-// /login, /admin, /api, /cap) stay out of the sitemap and disallowed in robots.
-const PUBLIC_ROUTES = ['/', '/get-account', '/status'];
+// Routes App.svelte renders that must stay OUT of the sitemap (auth-gated, no
+// indexable content). /admin and the non-SPA surfaces (/api, /cap) never appear
+// as pathname literals in the route switch and are asserted on robots directly.
+const NON_INDEXABLE = ['/account', '/login'];
+
+// The actual route switch: every `router.pathname === '/x'` literal.
+const routerRoutes = [...appSvelte.matchAll(/router\.pathname === '([^']+)'/g)].map((m) => m[1]);
+const indexableRoutes = routerRoutes.filter((route) => !NON_INDEXABLE.includes(route));
 
 describe('sitemap.xml', () => {
+  test('route extraction from App.svelte found the route switch', () => {
+    // Guards the regex above: a route-switch refactor that stops matching must
+    // fail loudly here, not let the sitemap assertions pass vacuously.
+    expect(routerRoutes).toContain('/');
+    expect(routerRoutes.length).toBeGreaterThanOrEqual(3);
+  });
+
   test('is a sitemaps.org urlset with an XML declaration', () => {
     expect(sitemap.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
     expect(sitemap).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
@@ -33,9 +47,11 @@ describe('sitemap.xml', () => {
     expect(noComments.match(/<url>/g)?.length).toBe(noComments.match(/<loc>/g)?.length);
   });
 
-  test('lists exactly the public routes, host-templated over https', () => {
+  test('lists exactly the indexable App.svelte routes, host-templated over https', () => {
     const locs = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
-    expect(locs).toEqual(PUBLIC_ROUTES.map((route) => `https://${HOST}${route}`));
+    expect([...locs].sort()).toEqual(
+      indexableRoutes.map((route) => `https://${HOST}${route}`).sort(),
+    );
   });
 });
 
@@ -44,13 +60,20 @@ describe('robots.txt', () => {
     expect(robots).toContain(`Sitemap: https://${HOST}/sitemap.xml`);
   });
 
-  test('disallows the non-content surfaces', () => {
-    for (const path of ['/account', '/login', '/admin', '/api/', '/cap/']) {
-      expect(robots).toContain(`Disallow: ${path}`);
+  test('disallows the non-content surfaces as bare prefixes', () => {
+    // Bare prefixes (no trailing slash): robots exclusions are path-prefix
+    // matches, and a slash-terminated `Disallow: /api/` would leave the exact
+    // URL `/api` crawlable (it misses Caddy's /api/* handler and falls through
+    // to the SPA with a 200).
+    for (const path of [...NON_INDEXABLE, '/admin', '/api', '/cap']) {
+      expect(robots).toContain(`Disallow: ${path}\n`);
     }
-    // /account must not shadow the public /get-account route (robots Disallow
-    // is a path-prefix match, so this only holds while the literal differs).
-    expect(robots).not.toContain('Disallow: /get');
+    // No disallow may prefix-shadow an indexable route (e.g. a hypothetical
+    // `Disallow: /get` would block the public /get-account).
+    const disallows = [...robots.matchAll(/^Disallow: (\S+)/gm)].map((m) => m[1]);
+    for (const route of indexableRoutes.filter((r) => r !== '/')) {
+      expect(disallows.some((d) => route.startsWith(d))).toBe(false);
+    }
   });
 });
 

--- a/src/client/lib/sitemap.test.ts
+++ b/src/client/lib/sitemap.test.ts
@@ -62,6 +62,14 @@ describe('robots.txt', () => {
     expect(robots).toContain(`Sitemap: https://${HOST}/sitemap.xml`);
   });
 
+  test('allows the render-critical public API GETs', () => {
+    // Crawler renderers honor robots.txt for the SPA's runtime fetches; these
+    // two hydrate the indexable pages (/status is entirely API-driven) and
+    // must out-match the /api disallow via the longest-match rule.
+    expect(robots).toContain('Allow: /api/v1/status\n');
+    expect(robots).toContain('Allow: /api/v1/config\n');
+  });
+
   test('disallows the non-content surfaces as bare prefixes', () => {
     // Bare prefixes (no trailing slash): robots exclusions are path-prefix
     // matches, and a slash-terminated `Disallow: /api/` would leave the exact

--- a/src/client/lib/sitemap.test.ts
+++ b/src/client/lib/sitemap.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+//
+// Pins public/sitemap.xml + public/robots.txt to the SPA's public route set and
+// to the Caddy templating that expands their host placeholders. Adding or
+// removing a public member-facing route (App.svelte's route switch) must update
+// PUBLIC_ROUTES here alongside the sitemap itself (and the telemetry
+// ROUTE_ALLOWLIST in convex/lib/umami.ts).
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+const root = resolve(__dirname, '../../..');
+const sitemap = readFileSync(resolve(root, 'public/sitemap.xml'), 'utf8');
+const robots = readFileSync(resolve(root, 'public/robots.txt'), 'utf8');
+const caddyfile = readFileSync(resolve(root, 'Caddyfile'), 'utf8');
+
+// Caddy expands this per request; the committed file must carry it verbatim so
+// every deployment serves same-host canonical URLs.
+const HOST = '{{placeholder "http.request.host"}}';
+
+// The indexable public routes. Auth-gated and non-content surfaces (/account,
+// /login, /admin, /api, /cap) stay out of the sitemap and disallowed in robots.
+const PUBLIC_ROUTES = ['/', '/get-account', '/status'];
+
+describe('sitemap.xml', () => {
+  test('is a sitemaps.org urlset with an XML declaration', () => {
+    expect(sitemap.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(sitemap).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(sitemap.trimEnd().endsWith('</urlset>')).toBe(true);
+    // Every <url> holds exactly one <loc> (structural sanity without a parser;
+    // XML comments stripped so prose mentioning the tags doesn't count).
+    const noComments = sitemap.replace(/<!--[\s\S]*?-->/g, '');
+    expect(noComments.match(/<url>/g)?.length).toBe(noComments.match(/<loc>/g)?.length);
+  });
+
+  test('lists exactly the public routes, host-templated over https', () => {
+    const locs = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+    expect(locs).toEqual(PUBLIC_ROUTES.map((route) => `https://${HOST}${route}`));
+  });
+});
+
+describe('robots.txt', () => {
+  test('references the host-templated sitemap URL', () => {
+    expect(robots).toContain(`Sitemap: https://${HOST}/sitemap.xml`);
+  });
+
+  test('disallows the non-content surfaces', () => {
+    for (const path of ['/account', '/login', '/admin', '/api/', '/cap/']) {
+      expect(robots).toContain(`Disallow: ${path}`);
+    }
+    // /account must not shadow the public /get-account route (robots Disallow
+    // is a path-prefix match, so this only holds while the literal differs).
+    expect(robots).not.toContain('Disallow: /get');
+  });
+});
+
+describe('Caddyfile templating', () => {
+  test('templates both files across the .txt and .xml MIME variants', () => {
+    expect(caddyfile).toContain('@seoFiles path /robots.txt /sitemap.xml');
+    expect(caddyfile).toMatch(
+      /templates @seoFiles \{\s*mime text\/plain text\/xml application\/xml\s*\}/,
+    );
+  });
+});


### PR DESCRIPTION
## What

Publishes a [Sitemaps-protocol](https://www.sitemaps.org/protocol.html) sitemap at `/sitemap.xml` and a `robots.txt` that references it:

- **`public/sitemap.xml`** — a sitemaps.org `<urlset>` listing the public, indexable SPA routes (`/`, `/get-account`, `/status`). Auth-gated and non-content surfaces (`/account`, `/login`, `/admin`, `/api`, `/cap`) are deliberately excluded.
- **`public/robots.txt`** — disallows those non-content paths and carries the required absolute `Sitemap:` URL.
- **`Caddyfile`** — a new path-scoped `templates @seoFiles` instance covering just these two files.
- **`src/client/lib/sitemap.test.ts`** — pins the route list, the robots directives, and the Caddy mime coverage.

## Why host-templated

The site host differs per deployment (`beta.freesocks.org` vs `freesocks.org`) and the protocol requires same-host canonical URLs, so a hardcoded host would be wrong on one stack and baking it in at build time would add build-arg wiring. Instead both files carry `{{placeholder "http.request.host"}}` and Caddy expands it per request — the same mechanism already used for the CSP nonce in `index.html`. The scheme is hardcoded `https` because the public origin is always TLS even when Caddy itself serves plain HTTP behind a terminating edge (`CADDY_SCHEME=http`).

## Reviewer notes

- The templates instance is deliberately **separate** from the existing `text/html` block and scoped to `path /robots.txt /sitemap.xml`: widening the existing block to `text/plain` would run template execution on every future `.txt` asset, where a stray `{{` would 500.
- The mime list covers both `text/xml` and `application/xml` since `.xml` mapping varies by system mime table (the pinned alpine image serves `text/xml; charset=utf-8`).
- The new test keeps the sitemap in sync with the route set: adding or removing a public member-facing route must update both (same convention as the telemetry `ROUTE_ALLOWLIST` in `convex/lib/umami.ts`).
- The Vite dev server serves the files raw (placeholders unexpanded) — they are production artifacts, noted in each file's header.

## Verification

- `caddy validate` passes under the exact pinned `caddy:2-alpine` digest CI uses.
- Ran the real Caddyfile in that image with `public/` mounted as the dist root: both files return HTTP 200 with the host expanded per request (`Content-Type: text/xml; charset=utf-8` for the sitemap).
- `xmllint --noout` confirms well-formedness; full suite green (1207 tests), lint + typecheck clean.
- Post-deploy: `curl https://<host>/sitemap.xml` should show the deployment host in every `<loc>`, and the isitagentready.com scan's `checks.discoverability.sitemap.status` should report `pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)