### PR TITLE
Fix the account globe's marker color under oklch brand presets

### DIFF
--- a/src/client/components/KeyLocationGlobe.svelte
+++ b/src/client/components/KeyLocationGlobe.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { t } from '../lib/i18n/index.svelte';
+  import { resolvePrimaryRgb } from '../lib/oklch';
 
   /**
    * The account page's location globe: every FreeSocks location with map
@@ -190,25 +191,15 @@
 
   onMount(() => {
     reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    // Theme-accurate marker green: resolve --primary to device RGB (falls back
-    // to the hardcoded triple on any parse miss, e.g. exotic color spaces).
-    try {
-      const probe = document.createElement('span');
-      probe.style.color = 'var(--primary)';
-      probe.style.display = 'none';
-      document.body.append(probe);
-      const resolved = getComputedStyle(probe).color;
-      probe.remove();
-      const m =
-        resolved.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/) ??
-        resolved.match(/color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/);
-      if (m) {
-        const scale = resolved.startsWith('color(') ? 1 : 255;
-        ACTIVE = [Number(m[1]) / scale, Number(m[2]) / scale, Number(m[3]) / scale];
-      }
-    } catch {
-      // keep the fallback triple
-    }
+    // Theme-accurate marker green: the theme declares --primary as oklch(),
+    // which computed styles can hand back verbatim (the brand-preset tokens
+    // do exactly that), so use the repo's oklch resolver rather than probing
+    // for an rgb() serialization - the old probe silently left the marker on
+    // the hardcoded emerald under a non-default brand preset (the same
+    // NetworkGlobe review finding, fixed there in e93c182). Falls back to the
+    // hardcoded triple when the token is unavailable or unparseable.
+    const rgb = resolvePrimaryRgb();
+    if (rgb) ACTIVE = [rgb[0] / 255, rgb[1] / 255, rgb[2] / 255];
     if (!canvas) return;
     const el = canvas;
     const dark = document.documentElement.classList.contains('dark');


### PR DESCRIPTION
## What changed

`KeyLocationGlobe.svelte` (the account page's location globe) now resolves its marker green through `resolvePrimaryRgb()` from `src/client/lib/oklch.ts`, keeping the hardcoded emerald triple only as the null fallback.

## Why

Same defect as the Codex review finding on the home globe fixed in `e93c182` (PR #37): the component probed `getComputedStyle` for an `rgb()` / `color(srgb ...)` serialization of `--primary`, but the brand-preset tokens (teal, indigo, classic) come back as `oklch()` verbatim, so the parse silently fell through and the member's key marker stayed hardcoded emerald while the rest of the page wore the configured primary.

## Notes for review

- This was the last copy of the rgb-probe pattern in the client; the other canvas color consumers were already oklch-safe (`DitherField` uses `resolvePrimaryRgb()`, `DitherChart` takes hex by contract, `QrCode` has the documented handling).
- Behavior-identical under the default theme; only non-default brand presets render differently (correctly, now).
- One-line functional change plus comment; typecheck, tests (1233), and lint are green. Easiest manual check: switch the brand preset in Admin → Settings and confirm the account globe's key marker follows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)