### PR TITLE
fix(remnawave): let migrateRemnawaveUserIds resume from a cursor

### DIFF
--- a/convex/backendServers.test.ts
+++ b/convex/backendServers.test.ts
@@ -484,6 +484,41 @@ describe('migrateRemnawaveUserIds (2.x uuid → instance-scoped 3.x id)', () => 
     expect(again.servers[0]).toMatchObject({ legacy: 1, remapped: 0, missing: 1 });
   });
 
+  test('an incomplete run reports a cursor and the next run RESUMES from it', async () => {
+    const t = convexTest(schema, modules);
+    const instanceId = await seedInstance(t, { slug: 'rw-big' });
+    const subs = await seedSubs(t, instanceId);
+    stubPanel('3.4.2', { sA: 5, sGone: 6 });
+    // pageSize 1 × maxPages 2: the first run cannot reach all 4 rows.
+    const first = await t.action(internal.backendServers.migrateRemnawaveUserIds, {
+      pageSize: 1,
+      maxPages: 2,
+    });
+    expect(first.servers[0]!.complete).toBe(false);
+    expect(first.servers[0]!.scanned).toBe(2);
+    expect(first.servers[0]!.continueCursor).toEqual(expect.any(String));
+    // Resume: the second run starts AFTER the rows already walked.
+    const second = await t.action(internal.backendServers.migrateRemnawaveUserIds, {
+      serverId: instanceId,
+      cursor: first.servers[0]!.continueCursor!,
+      pageSize: 1,
+      maxPages: 10,
+    });
+    expect(second.servers[0]!.complete).toBe(true);
+    expect(second.servers[0]!.continueCursor).toBeNull();
+    expect(first.servers[0]!.scanned + second.servers[0]!.scanned).toBe(4);
+    // Between the two runs every legacy row the panel knows got remapped.
+    expect(first.servers[0]!.remapped + second.servers[0]!.remapped).toBe(2);
+    await t.run(async (ctx) => {
+      expect((await ctx.db.get(subs.legacy))!.backendUserId).toBe(`${instanceId}:5`);
+      expect((await ctx.db.get(subs.gone))!.backendUserId).toBe(`${instanceId}:6`);
+    });
+    // A cursor without its panel is refused (it belongs to one row sequence).
+    await expect(
+      t.action(internal.backendServers.migrateRemnawaveUserIds, { cursor: 'abc' }),
+    ).rejects.toThrow(/cursor requires serverId/);
+  });
+
   test('a panel still on 2.x is skipped: its uuids are correct as they are', async () => {
     const t = convexTest(schema, modules);
     const instanceId = await seedInstance(t, { slug: 'rw-2x' });

--- a/convex/backendServers.ts
+++ b/convex/backendServers.ts
@@ -363,7 +363,12 @@ export const hardenRemnawaveLogging = internalAction({
  * version is skipped outright (its keys are correct as they are). A key the
  * panel no longer knows is counted as `missing` and left alone for the operator
  * (its tombstone/regenerate path will surface it). Bounded per run by
- * `maxPages` (100 rows each); the report says whether a rerun is needed.
+ * `maxPages` × `pageSize` rows (50 × 100 by default, to stay inside one
+ * action's time budget); an incomplete run reports `continueCursor`, which the
+ * next run takes as `cursor` (+ `serverId`) to RESUME — a run without a cursor
+ * starts from the panel's first row again (cheap for already-scoped rows, but
+ * it never gets past `maxPages` on a large fleet, which is how prod stalled on
+ * 2026-09-03 before this arg existed).
  */
 /** Per-instance report row of `migrateRemnawaveUserIds`. */
 interface UserIdMigrationRow {
@@ -378,6 +383,10 @@ interface UserIdMigrationRow {
   failed: number;
   conflicts: number;
   complete: boolean;
+  // Where this run stopped when `complete` is false: pass it back as `cursor`
+  // (with the same `serverId`) so the next run RESUMES instead of re-walking
+  // the rows already done. Null once the panel's rows are exhausted.
+  continueCursor: string | null;
 }
 
 export const migrateRemnawaveUserIds = internalAction({
@@ -385,11 +394,17 @@ export const migrateRemnawaveUserIds = internalAction({
     dryRun: v.optional(v.boolean()),
     serverId: v.optional(v.id('backendServers')),
     maxPages: v.optional(v.number()),
+    pageSize: v.optional(v.number()),
+    // Resume point from a previous run's `continueCursor` (requires `serverId`:
+    // a cursor is only meaningful within one panel's row sequence).
+    cursor: v.optional(v.string()),
   },
   handler: async (
     ctx,
-    { dryRun = false, serverId, maxPages = 50 },
+    { dryRun = false, serverId, maxPages = 50, pageSize = 100, cursor: startCursor },
   ): Promise<{ dryRun: boolean; servers: UserIdMigrationRow[] }> => {
+    if (startCursor !== undefined && !serverId)
+      throw new Error('cursor requires serverId (a cursor belongs to one panel)');
     const all = serverId
       ? [await ctx.runQuery(internal.backendServers.getById, { id: serverId })]
       : await ctx.runQuery(internal.backendServers.listActiveWithSecret, {});
@@ -408,6 +423,7 @@ export const migrateRemnawaveUserIds = internalAction({
         failed: 0,
         conflicts: 0,
         complete: true,
+        continueCursor: null,
       };
       let major: number | null = null;
       try {
@@ -421,7 +437,7 @@ export const migrateRemnawaveUserIds = internalAction({
         out.push({ ...row, skipped: 'panel is not 3.x — its 2.x uuids are still correct' });
         continue;
       }
-      let cursor: string | null = null;
+      let cursor: string | null = startCursor ?? null;
       let pages = 0;
       do {
         const page: {
@@ -436,7 +452,7 @@ export const migrateRemnawaveUserIds = internalAction({
         } = await ctx.runQuery(internal.subscriptions.listByServerPage, {
           backendServerId: s!._id,
           cursor,
-          numItems: 100,
+          numItems: pageSize,
         });
         for (const sub of page.page) {
           row.scanned++;
@@ -481,6 +497,7 @@ export const migrateRemnawaveUserIds = internalAction({
         pages++;
       } while (cursor !== null && pages < maxPages);
       row.complete = cursor === null;
+      row.continueCursor = cursor;
       if (!dryRun && row.remapped > 0) {
         await ctx.runMutation(internal.audit.record, {
           actorType: 'system',

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -284,8 +284,11 @@ are untouched (the migration skips any panel that reports a 2.x version).
    bunx convex run backendServers:migrateRemnawaveUserIds '{}'
    ```
 
-   Pass `"serverId": "<backendServers _id>"` to limit it to one panel, and rerun while
-   `complete` is false (each run walks up to 50 pages of 100 rows per panel). The remap is
+   Each run walks up to 50 pages of 100 rows per panel (one action's time budget). While
+   `complete` is false the report carries `continueCursor`: rerun with
+   `{"serverId": "<that panel's serverId>", "cursor": "<continueCursor>"}` to RESUME from there
+   (a run without a cursor starts over from the panel's first row, so on a large fleet it would
+   never get past the first 5,000). `serverId` alone limits a run to one panel. The remap is
    compare-and-set and skips rows that are already scoped, so reruns are safe; every write
    run audits `admin.remnawave.user_ids_migrated` with the counts. `missing` rows are keys the
    panel no longer knows (the member's next regenerate re-issues them); `conflicts` means the


### PR DESCRIPTION
Hotfix: each migration run restarted pagination from the first row, so a fleet larger than 5,000 rows never progressed past the first page window (prod stalled at 4,780/~34k during the 2026-09-03 panel upgrade). The report now carries `continueCursor`; pass it back as `cursor` with `serverId` to resume. Unit-tested at pageSize 1. Typecheck + lint + tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)