### PR TITLE
fix(admin): counter-backed status query + bounded reads past the Convex read limit

### DIFF
--- a/convex/adminApi.test.ts
+++ b/convex/adminApi.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest';
 import schema from './schema';
 import { internal } from './_generated/api';
 import { maskApiUrl } from './adminApi';
+import { POP_ALG_ED } from '../src/shared/crypto/pop';
 import { resolveTheme } from './lib/themeConfig';
 import { resolveModeSquadPool } from './lib/remnawavePlacement';
 import { UserAdmin, AdminStatusSummary } from '../src/shared/contracts/admin';
@@ -833,6 +834,11 @@ describe('adminApi statusSummary', () => {
       });
     });
 
+    // Rows seeded directly bypass the per-write counter bumps: run the sweep
+    // (deletes the expired row, as the daily cron does) and rebuild the counter
+    // from the table, the same way the deploy entrypoint does.
+    await t.mutation(internal.sessions.sweepExpired, {});
+    await t.action(internal.userStats.reconcileSessionCounts, {});
     const s = await t.query(internal.adminApi.statusSummary, {});
     expect(s.pop.activeSessions).toBe(3); // the expired row is not counted
     expect(s.pop.bound).toBe(1);
@@ -841,6 +847,67 @@ describe('adminApi statusSummary', () => {
     expect(s.pop.unboundAdmin).toBe(1);
     expect(s.pop.readyToEnable).toBe(false); // cookie-only sessions would be locked out
     expect(s.pop.required).toBe(false); // POP_REQUIRED unset in tests
+  });
+
+  // 2026-09-04 prod incident: the tally used to `.collect()` every live session
+  // and 500-ed the whole status endpoint once prod crossed Convex's per-execution
+  // read limit. It now reads the `stats:sessionCounts` counter, bumped by every
+  // session write path — so NO reconcile is needed for rows created the real way.
+  test('pop readiness is live: session create/delete/sweep bump the counter', async () => {
+    const t = convexTest(schema, modules);
+    const edKey = 'A'.repeat(43); // 32 zero bytes base64url = a length-valid Ed25519 key
+    const ttl = 3_600_000;
+    await t.mutation(internal.sessions.create, {
+      sid: 'bound-1',
+      kind: 'member',
+      ttlMs: ttl,
+      popPublicKey: edKey,
+      popAlg: POP_ALG_ED,
+      popSessionToken: 'tok',
+    });
+    await t.mutation(internal.sessions.create, { sid: 'cookie-m', kind: 'member', ttlMs: ttl });
+    await t.mutation(internal.sessions.create, { sid: 'cookie-a', kind: 'admin', ttlMs: ttl });
+    await t.mutation(internal.sessions.create, { sid: 'short', kind: 'member', ttlMs: -1 }); // already expired
+
+    let s = await t.query(internal.adminApi.statusSummary, {});
+    expect(s.pop).toMatchObject({
+      activeSessions: 4, // present rows; the expired one stays counted until swept
+      bound: 1,
+      unboundMember: 2,
+      unboundAdmin: 1,
+      unbound: 3,
+      readyToEnable: false,
+    });
+
+    await t.mutation(internal.sessions.sweepExpired, {}); // drops 'short'
+    await t.mutation(internal.sessions.deleteBySid, { sid: 'cookie-a' });
+    s = await t.query(internal.adminApi.statusSummary, {});
+    expect(s.pop).toMatchObject({ activeSessions: 2, bound: 1, unboundMember: 1, unboundAdmin: 0 });
+
+    await t.mutation(internal.sessions.deleteBySid, { sid: 'cookie-m' });
+    s = await t.query(internal.adminApi.statusSummary, {});
+    expect(s.pop).toMatchObject({ activeSessions: 1, bound: 1, unbound: 0, readyToEnable: true });
+
+    // Reconcile agrees with the live bumps (no drift) and is idempotent.
+    await t.action(internal.userStats.reconcileSessionCounts, {});
+    expect((await t.query(internal.adminApi.statusSummary, {})).pop.activeSessions).toBe(1);
+  });
+
+  test('statusSummary stays O(1) in session rows (no per-session read)', async () => {
+    // Pin the shape rather than the limit itself: seed more rows than a single
+    // bounded page and confirm the query never reads them (counter only).
+    const t = convexTest(schema, modules);
+    const future = Date.now() + 3_600_000;
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 600; i++) {
+        await ctx.db.insert('sessions', { sid: `s-${i}`, kind: 'member', expiresAt: future });
+      }
+    });
+    // Nothing bumped the counter, so the query reports zero — proof it read the
+    // counter, not the table. The reconcile then catches the table up.
+    expect((await t.query(internal.adminApi.statusSummary, {})).pop.activeSessions).toBe(0);
+    await t.action(internal.userStats.reconcileSessionCounts, {});
+    expect((await t.query(internal.adminApi.statusSummary, {})).pop.activeSessions).toBe(600);
   });
 
   test('pop readiness: readyToEnable once every active session is key-bound', async () => {
@@ -884,6 +951,7 @@ describe('adminApi statusSummary', () => {
       });
     });
 
+    await t.action(internal.userStats.reconcileSessionCounts, {});
     const s = await t.query(internal.adminApi.statusSummary, {});
     expect(s.pop.unbound).toBe(0);
     expect(s.pop.bound).toBe(2);
@@ -1234,6 +1302,65 @@ describe('admin mutation audit coverage', () => {
     ]);
     expect(JSON.stringify(rows)).not.toContain('SECRET-NEVER-AUDIT');
     expect(JSON.stringify(rows)).not.toContain('panel.example');
+  });
+
+  test('deleting a backend server refuses while a live key points at it (both paths)', async () => {
+    const t = convexTest(schema, modules);
+    const created = await t.mutation(internal.adminApi.createBackendServer, {
+      backend: 'remnawave',
+      name: 'RW Busy',
+      slug: 'rw-busy',
+      baseUrl: 'https://panel.example',
+      apiToken: 'tok',
+    });
+    const serverId = created.id as never as import('./_generated/dataModel').Id<'backendServers'>;
+    const subId = await t.run(async (ctx) => {
+      const tierId = await ctx.db.insert('tiers', {
+        slug: 'free',
+        name: 'Free',
+        backend: 'remnawave',
+        monthlyTrafficGb: 50,
+        deviceLimit: 1,
+        hwidLimit: 1,
+        hwidEnabled: true,
+        trafficStrategy: 'MONTH',
+        isDefaultFree: true,
+        isActive: true,
+        priority: 0,
+        expirationDaysAfterMembershipLapse: 0,
+        updatedAt: Date.now(),
+      });
+      const userId = await ctx.db.insert('users', {
+        tierId,
+        status: 'active',
+        updatedAt: Date.now(),
+      });
+      return ctx.db.insert('subscriptions', {
+        userId,
+        backend: 'remnawave',
+        backendUserId: 'u-1',
+        backendShortId: 'short-1',
+        subscriptionUrl: 'https://panel.example/sub/short-1',
+        subscriptionMirrors: [],
+        backendServerId: serverId,
+        state: 'disabled', // tombstoned-but-not-yet-reclaimed still counts as live
+        updatedAt: Date.now(),
+      });
+    });
+
+    await expect(
+      t.mutation(internal.adminApi.deleteBackendServer, { id: serverId }),
+    ).rejects.toMatchObject({ data: { code: 'server.in_use' } });
+    await expect(
+      t.mutation(internal.adminApi.deleteBackendServerBySlug, { slug: 'rw-busy' }),
+    ).rejects.toMatchObject({ data: { code: 'server.in_use' } });
+
+    // A fully deleted (retention-pending) key no longer blocks the delete.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(subId, { state: 'deleted', deletedAt: Date.now() });
+    });
+    const del = await t.mutation(internal.adminApi.deleteBackendServerBySlug, { slug: 'rw-busy' });
+    expect(del).toEqual({ ok: true, deleted: true });
   });
 
   test('mirror-provider create/update/upsert/remove audit (name only, never the secret)', async () => {

--- a/convex/adminApi.test.ts
+++ b/convex/adminApi.test.ts
@@ -855,6 +855,9 @@ describe('adminApi statusSummary', () => {
   // session write path — so NO reconcile is needed for rows created the real way.
   test('pop readiness is live: session create/delete/sweep bump the counter', async () => {
     const t = convexTest(schema, modules);
+    // The counter row is born by the first reconcile (deploy entrypoint); bumps
+    // before that are deliberate no-ops (fail-closed, see the P2 test below).
+    await t.action(internal.userStats.reconcileSessionCounts, {});
     const edKey = 'A'.repeat(43); // 32 zero bytes base64url = a length-valid Ed25519 key
     const ttl = 3_600_000;
     await t.mutation(internal.sessions.create, {
@@ -893,7 +896,7 @@ describe('adminApi statusSummary', () => {
     expect((await t.query(internal.adminApi.statusSummary, {})).pop.activeSessions).toBe(1);
   });
 
-  test('statusSummary stays O(1) in session rows (no per-session read)', async () => {
+  test('statusSummary stays O(1) in session rows and fails closed before the first reconcile', async () => {
     // Pin the shape rather than the limit itself: seed more rows than a single
     // bounded page and confirm the query never reads them (counter only).
     const t = convexTest(schema, modules);
@@ -903,11 +906,23 @@ describe('adminApi statusSummary', () => {
         await ctx.db.insert('sessions', { sid: `s-${i}`, kind: 'member', expiresAt: future });
       }
     });
-    // Nothing bumped the counter, so the query reports zero — proof it read the
-    // counter, not the table. The reconcile then catches the table up.
-    expect((await t.query(internal.adminApi.statusSummary, {})).pop.activeSessions).toBe(0);
+    // No counter row yet: the query reports UNKNOWN (not "0 unbound → safe") —
+    // the first-rollout window between `convex deploy` and the entrypoint's
+    // reconcile must never read as ready (review P2).
+    let s = await t.query(internal.adminApi.statusSummary, {});
+    expect(s.pop.initialized).toBe(false);
+    expect(s.pop.activeSessions).toBe(0);
+    expect(s.pop.readyToEnable).toBe(false);
+    // Bumps before the row exists are no-ops (the reconcile overwrites anyway).
+    await t.mutation(internal.sessions.create, { sid: 'pre-init', kind: 'member', ttlMs: 60_000 });
+    expect((await t.query(internal.adminApi.statusSummary, {})).pop.initialized).toBe(false);
+    // The reconcile builds the row from the table (600 seeded + 1 created).
     await t.action(internal.userStats.reconcileSessionCounts, {});
-    expect((await t.query(internal.adminApi.statusSummary, {})).pop.activeSessions).toBe(600);
+    s = await t.query(internal.adminApi.statusSummary, {});
+    expect(s.pop.initialized).toBe(true);
+    expect(s.pop.activeSessions).toBe(601);
+    expect(s.pop.unboundMember).toBe(601);
+    expect(s.pop.readyToEnable).toBe(false);
   });
 
   test('pop readiness: readyToEnable once every active session is key-bound', async () => {

--- a/convex/adminApi.ts
+++ b/convex/adminApi.ts
@@ -25,7 +25,7 @@ import type { Doc, Id } from './_generated/dataModel';
 import { ConvexError, v } from 'convex/values';
 import { writeAuditLog } from './lib/audit';
 import { backendIdValidator, type BackendId } from './lib/backendIds';
-import { applyCountsDelta, readUserCounts } from './lib/statusCounters';
+import { applyCountsDelta, readSessionCounts, readUserCounts } from './lib/statusCounters';
 // One shared by-key upsert (Review P3): the local upsertSetting + setBillingConfig's
 // inline copy both delegate here (also appSettings.set/setMany use it).
 import { upsertSettingRow as upsertSetting } from './appSettings';
@@ -1390,6 +1390,32 @@ export const updateBackendServer = internalMutation({
   },
 });
 
+/**
+ * Throw `server.in_use` while any non-deleted subscription still points at the
+ * instance. ONE bounded read per live state via the (backendServerId, state)
+ * index — the former `.collect()` of every subscription on the panel would trip
+ * Convex's per-execution read limit (8 MiB / 32k docs; sub docs carry subCache)
+ * on any real panel and 500 instead of rejecting (2026-09-04 audit).
+ */
+async function assertBackendServerUnused(
+  db: DatabaseReader,
+  id: Id<'backendServers'>,
+): Promise<void> {
+  for (const state of ['active', 'disabled'] as const) {
+    const live = await db
+      .query('subscriptions')
+      .withIndex('by_backend_server_state', (q) => q.eq('backendServerId', id).eq('state', state))
+      .first();
+    if (live) {
+      throw new ConvexError({
+        code: 'server.in_use',
+        message:
+          'Cannot delete an instance that still has keys on it. Migrate or tombstone them first.',
+      });
+    }
+  }
+}
+
 export const deleteBackendServer = internalMutation({
   args: { id: v.id('backendServers'), actorAdminId: v.optional(v.id('adminUsers')) },
   handler: async (ctx, { id, actorAdminId }) => {
@@ -1397,17 +1423,7 @@ export const deleteBackendServer = internalMutation({
     // Refuse while live keys point at the instance (they'd be unresolvable
     // orphans for reads/updates/teardowns). Convex has no FK enforcement.
     // Tombstoned/deleted rows don't count (the retention sweep reclaims them).
-    const referencing = await ctx.db
-      .query('subscriptions')
-      .withIndex('by_backend_server', (q) => q.eq('backendServerId', id))
-      .collect();
-    if (referencing.some((s) => s.state !== 'deleted')) {
-      throw new ConvexError({
-        code: 'server.in_use',
-        message:
-          'Cannot delete an instance that still has keys on it. Migrate or tombstone them first.',
-      });
-    }
+    await assertBackendServerUnused(ctx.db, id);
     await ctx.db.delete(id);
     // Its node-stats cache rows dangle otherwise (the picker would keep
     // attributing squads to a gone panel).
@@ -1534,6 +1550,9 @@ export const deleteBackendServerBySlug = internalMutation({
       .withIndex('by_slug', (q) => q.eq('slug', slug))
       .unique();
     if (!row) return { ok: true as const, deleted: false };
+    // Same in-use guard as the by-id path (this is the Ansible route; it used
+    // to delete unconditionally and orphan every key on the panel).
+    await assertBackendServerUnused(ctx.db, row._id);
     await ctx.db.delete(row._id);
     await writeAuditLog(ctx, {
       actorType: 'admin',
@@ -1821,23 +1840,21 @@ export const statusSummary = internalQuery({
     // flip an observed decision instead of a timed guess, and it also surfaces
     // clients that log in but cannot enroll a key (they show as persistent
     // unbound sessions and would be locked out by the flip).
-    // NOTE: O(active sessions) — bounded by live logins; fine at beta scale.
-    const liveSessions = await ctx.db
-      .query('sessions')
-      .withIndex('by_expires', (q) => q.gt('expiresAt', now))
-      .collect();
-    let popBound = 0;
-    let unboundMember = 0;
-    let unboundAdmin = 0;
-    for (const row of liveSessions) {
-      if (row.popPublicKey != null) popBound += 1;
-      else if (row.kind === 'admin') unboundAdmin += 1;
-      else unboundMember += 1;
-    }
+    //
+    // Read from the maintained `stats:sessionCounts` counter (statusCounters.ts,
+    // bumped at every session insert/delete, rebuilt daily by
+    // userStats.reconcileSessionCounts) — the former `.collect()` over live
+    // sessions 500-ed this endpoint on prod once it crossed Convex's 32k-document
+    // per-execution read limit (2026-09-04). Live to the last login/logout;
+    // sessions that silently age past their TTL stay counted until the daily
+    // sweep deletes them (bounded overstatement, conservative for readiness).
+    const sessionCounts = await readSessionCounts(ctx.db);
+    const unboundMember = sessionCounts.unboundMember;
+    const unboundAdmin = sessionCounts.unboundAdmin;
     const pop = {
       required: process.env.POP_REQUIRED === 'true',
-      activeSessions: liveSessions.length,
-      bound: popBound,
+      activeSessions: sessionCounts.bound + unboundMember + unboundAdmin,
+      bound: sessionCounts.bound,
       unbound: unboundMember + unboundAdmin,
       unboundMember,
       unboundAdmin,

--- a/convex/adminApi.ts
+++ b/convex/adminApi.ts
@@ -1848,18 +1848,22 @@ export const statusSummary = internalQuery({
     // per-execution read limit (2026-09-04). Live to the last login/logout;
     // sessions that silently age past their TTL stay counted until the daily
     // sweep deletes them (bounded overstatement, conservative for readiness).
-    const sessionCounts = await readSessionCounts(ctx.db);
+    // `initialized` is false until the first reconcile has run (first deploy of
+    // the counter, or a failed post-deploy reconcile): the figures are then
+    // unknown, so readiness fails CLOSED instead of reading zeros as "safe".
+    const { counts: sessionCounts, initialized } = await readSessionCounts(ctx.db);
     const unboundMember = sessionCounts.unboundMember;
     const unboundAdmin = sessionCounts.unboundAdmin;
     const pop = {
       required: process.env.POP_REQUIRED === 'true',
+      initialized,
       activeSessions: sessionCounts.bound + unboundMember + unboundAdmin,
       bound: sessionCounts.bound,
       unbound: unboundMember + unboundAdmin,
       unboundMember,
       unboundAdmin,
       // Nothing relies on cookie-only auth → enabling POP_REQUIRED logs no one out.
-      readyToEnable: unboundMember + unboundAdmin === 0,
+      readyToEnable: initialized && unboundMember + unboundAdmin === 0,
     };
     // CDN-blinding E2EE posture (H1): FS_E2EE_REQUIRED rejects unsealed member
     // requests on seal/reveal routes. `required` is the server flag; the SPA

--- a/convex/adminApi.ts
+++ b/convex/adminApi.ts
@@ -689,7 +689,11 @@ export const disableUser = internalMutation({
       suspendedAt: Date.now(),
       updatedAt: Date.now(),
     });
-    await applyCountsDelta(ctx, { statusFrom: user.status, statusTo: 'disabled' });
+    await applyCountsDelta(ctx, {
+      statusFrom: user.status,
+      statusTo: 'disabled',
+      creationTime: user._creationTime,
+    });
     await writeAuditLog(ctx, {
       actorType: 'admin',
       actorId: actorAdminId ?? undefined,
@@ -721,7 +725,11 @@ export const reEnableUser = internalMutation({
       suspendedAt: undefined,
       updatedAt: Date.now(),
     });
-    await applyCountsDelta(ctx, { statusFrom: 'disabled', statusTo: 'active' });
+    await applyCountsDelta(ctx, {
+      statusFrom: 'disabled',
+      statusTo: 'active',
+      creationTime: user._creationTime,
+    });
     await writeAuditLog(ctx, {
       actorType: 'admin',
       actorId: actorAdminId ?? undefined,

--- a/convex/cronHeartbeat.ts
+++ b/convex/cronHeartbeat.ts
@@ -76,6 +76,11 @@ export const CRON_META: { name: string; everyMs: number; description: string }[]
     everyMs: DAY,
     description: 'Recompute the user-status counter (self-heal)',
   },
+  {
+    name: 'session-counts-reconcile',
+    everyMs: DAY,
+    description: 'Recompute the session counter behind the PoP tally (self-heal)',
+  },
   { name: 'session-sweep', everyMs: DAY, description: 'Drop expired session rows' },
   { name: 'rate-limit-sweep', everyMs: DAY, description: 'Drop expired rate-limit rows' },
   {

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -157,5 +157,13 @@ crons.daily(
   internal.userStats.reconcileUserCounts,
   {},
 );
+// Same self-heal for the session counter behind statusSummary's PoP tally
+// (bumped live on every session insert/delete; this corrects any missed bump).
+crons.daily(
+  'session-counts-reconcile',
+  { hourUTC: 4, minuteUTC: 10 },
+  internal.userStats.reconcileSessionCounts,
+  {},
+);
 
 export default crons;

--- a/convex/freeTier.ts
+++ b/convex/freeTier.ts
@@ -69,7 +69,8 @@ export const createFreeUser = internalMutation({
       freeKeyExpiresAt: await freeWindowExpiryMs(ctx.db),
       updatedAt: now,
     });
-    await applyCountsDelta(ctx, { statusTo: 'active' });
+    const created = await ctx.db.get(userId);
+    await applyCountsDelta(ctx, { statusTo: 'active', creationTime: created!._creationTime });
     return { userId };
   },
 });
@@ -85,6 +86,7 @@ export const deleteFreeUser = internalMutation({
     await applyCountsDelta(ctx, {
       statusFrom: u.status,
       driftDelta: u.backendPushFailedAt != null ? -1 : 0,
+      creationTime: u._creationTime,
     });
     return null;
   },

--- a/convex/lib/statusCounters.ts
+++ b/convex/lib/statusCounters.ts
@@ -1,19 +1,310 @@
 /**
- * Maintained user-status counters (M2 / WS3). `adminApi.statusSummary` used to
- * `collect()` the whole users table — an O(users) read that throws past Convex's
- * per-query read limit (500-ing the /status health-gate). Instead we keep a single
- * hot counter row in `appState` (key `stats:userCounts`), bumped on every status
- * transition, and `reconcileUserCounts` (userStats.ts) rebuilds it exactly + self-
- * heals any drift. Read-modify-write inside the caller's own transaction; the
- * Math.max(0,…) clamp keeps it fail-safe before the first reconcile/backfill.
+ * Maintained counters (M2 / WS3 + the 2026-09-04 prod incident). Reading a
+ * traffic-scaled table wholesale trips Convex's per-execution read limit
+ * (32k documents / 8 MiB) — `adminApi.statusSummary` 500-ed on it twice: the
+ * users tally (2026-06) and the live-sessions PoP tally (2026-09-04). Each
+ * figure therefore lives in a hot `appState` row bumped inside the transaction
+ * that changes it, and is rebuilt exactly by a paginated reconcile.
+ *
+ * Exactness under concurrency (the naive live+(scanned−baseline) delta write
+ * double-applied any change landing before the scan reached its row — review
+ * P1). One protocol for every counter here:
+ *   • `begin` pins startTs = the newest row's `_creationTime` visible to it.
+ *     Every later commit gets a strictly larger `_creationTime`, so the scan
+ *     covers a FIXED set of rows (≤ startTs) and a row created mid-scan is
+ *     never in it.
+ *   • The scan advances a `scanPos` boundary; each page is read AND its
+ *     scanPos recorded in the SAME mutation, so for any concurrent change on
+ *     row c there is no gap: either the scan already saw c's new state
+ *     (c > scanPos when the change committed → nothing to add) or the scan
+ *     will never see it (c ≤ scanPos, already read with the old state — or
+ *     c > startTs, outside the set) → the change is recorded in a `journal`.
+ *     A page that ends on a shared `_creationTime` pulls the rest of that
+ *     timestamp in, so scanPos never splits equal timestamps.
+ *   • `finish` writes scanned + journal, and skips if a newer `begin`
+ *     superseded it.
+ * The row also carries `initialized` (review P2): until the first reconcile
+ * completed, the counts are unknown — readers that make safety decisions on
+ * them (`pop.readyToEnable`) fail CLOSED. Rows written before the flag existed
+ * read as `legacyInitialized` (users: exact prod rows → true).
  */
 import type { MutationCtx, DatabaseReader } from '../_generated/server';
+import type { Doc, TableNames } from '../_generated/dataModel';
+
+// ---------------------------------------------------------------------------
+// Generic protocol
+// ---------------------------------------------------------------------------
+
+export interface CounterSpec<C extends Record<string, number>, T extends TableNames> {
+  /** The `appState` key. */
+  key: string;
+  /** The table the reconcile scans. */
+  table: T;
+  zero: C;
+  /** How a row lacking the `initialized` field reads. */
+  legacyInitialized: boolean;
+  /** Bumps on a missing row: create it (legacy behaviour) or no-op (fail-closed;
+   *  the first reconcile creates the row and overwrites anything bumps would
+   *  have built). */
+  createOnBump: boolean;
+}
+
+interface ReconcileState<C> {
+  /** Run token (a persisted sequence, so two `begin`s that pin the same
+   *  boundary are still told apart); `finish` must present it. */
+  token: number;
+  startTs: number;
+  /** `_creationTime` up to which the scan has read (inclusive). -1 = nothing yet. */
+  scanPos: number;
+  scanned: C;
+  journal: C;
+}
+
+type CounterState<C> = {
+  counts: C;
+  initialized: boolean;
+  /** Monotonic reconcile-run counter (survives finish, so tokens never repeat). */
+  runSeq: number;
+  reconcile?: ReconcileState<C>;
+};
+
+function pickCounts<C extends Record<string, number>>(zero: C, raw: unknown): C {
+  const out = { ...zero };
+  if (raw && typeof raw === 'object') {
+    for (const k of Object.keys(zero) as (keyof C)[]) {
+      const v = (raw as Record<string, unknown>)[k as string];
+      if (typeof v === 'number' && Number.isFinite(v)) out[k] = v as C[keyof C];
+    }
+  }
+  return out;
+}
+
+function parseState<C extends Record<string, number>, T extends TableNames>(
+  spec: CounterSpec<C, T>,
+  value: string,
+): CounterState<C> {
+  try {
+    const raw = JSON.parse(value) as Record<string, unknown>;
+    const st: CounterState<C> = {
+      counts: pickCounts(spec.zero, raw),
+      initialized: typeof raw.initialized === 'boolean' ? raw.initialized : spec.legacyInitialized,
+      runSeq: typeof raw.runSeq === 'number' ? raw.runSeq : 0,
+    };
+    const rec = raw.reconcile as Partial<ReconcileState<unknown>> | undefined;
+    if (rec && typeof rec.startTs === 'number' && typeof rec.token === 'number') {
+      st.reconcile = {
+        token: rec.token,
+        startTs: rec.startTs,
+        scanPos: typeof rec.scanPos === 'number' ? rec.scanPos : -1,
+        scanned: pickCounts(spec.zero, rec.scanned),
+        journal: pickCounts(spec.zero, rec.journal),
+      };
+    }
+    return st;
+  } catch {
+    return { counts: { ...spec.zero }, initialized: false, runSeq: 0 };
+  }
+}
+
+/** Flat storage: the count fields at the top level (backward compatible with
+ *  the pre-protocol rows) + the two meta fields. */
+function serialize<C extends Record<string, number>>(st: CounterState<C>): string {
+  return JSON.stringify({
+    ...st.counts,
+    initialized: st.initialized,
+    runSeq: st.runSeq,
+    ...(st.reconcile ? { reconcile: st.reconcile } : {}),
+  });
+}
+
+async function readRow(db: DatabaseReader, key: string) {
+  return db
+    .query('appState')
+    .withIndex('by_key', (q) => q.eq('key', key))
+    .unique();
+}
+
+async function writeState<C extends Record<string, number>, T extends TableNames>(
+  ctx: MutationCtx,
+  spec: CounterSpec<C, T>,
+  st: CounterState<C>,
+  rowId?: Doc<'appState'>['_id'],
+): Promise<void> {
+  const value = serialize(st);
+  if (rowId) await ctx.db.patch(rowId, { value, updatedAt: Date.now() });
+  else await ctx.db.insert('appState', { key: spec.key, value, updatedAt: Date.now() });
+}
+
+export async function readCounter<C extends Record<string, number>, T extends TableNames>(
+  db: DatabaseReader,
+  spec: CounterSpec<C, T>,
+): Promise<{ counts: C; initialized: boolean }> {
+  const row = await readRow(db, spec.key);
+  if (!row) return { counts: { ...spec.zero }, initialized: false };
+  const st = parseState(spec, row.value);
+  return { counts: st.counts, initialized: st.initialized };
+}
+
+export interface CounterDelta<C> {
+  delta: Partial<C>;
+  /** `_creationTime` of the row the change is about (the journal boundary test). */
+  creationTime: number;
+}
+
+/** Apply signed deltas inside the caller's transaction (clamped ≥ 0) and, while
+ *  a reconcile is open, journal the ones the scan cannot account for. */
+export async function applyCounterDeltas<C extends Record<string, number>, T extends TableNames>(
+  ctx: MutationCtx,
+  spec: CounterSpec<C, T>,
+  items: readonly CounterDelta<C>[],
+): Promise<void> {
+  const live = items.filter((it) => Object.values(it.delta).some((d) => d !== 0 && d != null));
+  if (live.length === 0) return;
+  const row = await readRow(ctx.db, spec.key);
+  if (!row && !spec.createOnBump) return;
+  const st: CounterState<C> = row
+    ? parseState(spec, row.value)
+    : { counts: { ...spec.zero }, initialized: spec.legacyInitialized, runSeq: 0 };
+  for (const it of live) {
+    const rec = st.reconcile;
+    const journal =
+      rec != null && (it.creationTime > rec.startTs || it.creationTime <= rec.scanPos);
+    for (const [k, d] of Object.entries(it.delta) as [keyof C, number | undefined][]) {
+      if (!d) continue;
+      st.counts[k] = Math.max(0, st.counts[k] + d) as C[keyof C];
+      if (journal && rec) rec.journal[k] = (rec.journal[k] + d) as C[keyof C];
+    }
+  }
+  await writeState(ctx, spec, st, row?._id);
+}
+
+/** Overwrite selected count fields, preserving the others + the meta fields.
+ *  (A targeted recount such as `refreshFreeActive`.) */
+export async function patchCounterCounts<C extends Record<string, number>, T extends TableNames>(
+  ctx: MutationCtx,
+  spec: CounterSpec<C, T>,
+  partial: Partial<C>,
+): Promise<void> {
+  const row = await readRow(ctx.db, spec.key);
+  const st: CounterState<C> = row
+    ? parseState(spec, row.value)
+    : { counts: { ...spec.zero }, initialized: spec.legacyInitialized, runSeq: 0 };
+  for (const [k, v] of Object.entries(partial) as [keyof C, number | undefined][]) {
+    if (v != null) st.counts[k] = Math.max(0, v) as C[keyof C];
+  }
+  await writeState(ctx, spec, st, row?._id);
+}
+
+/** Open a reconcile: pin the scan boundary, reset the scan + journal. Creates
+ *  the row (uninitialized) when absent. Returns the run token `finish` needs.
+ *  A second `begin` while one is open supersedes it. */
+export async function beginCounterReconcile<C extends Record<string, number>, T extends TableNames>(
+  ctx: MutationCtx,
+  spec: CounterSpec<C, T>,
+): Promise<number> {
+  const newest = await ctx.db.query(spec.table).order('desc').first();
+  const startTs = newest?._creationTime ?? 0;
+  const row = await readRow(ctx.db, spec.key);
+  const st: CounterState<C> = row
+    ? parseState(spec, row.value)
+    : { counts: { ...spec.zero }, initialized: false, runSeq: 0 };
+  const token = st.runSeq + 1;
+  st.runSeq = token;
+  st.reconcile = {
+    token,
+    startTs,
+    scanPos: -1,
+    scanned: { ...spec.zero },
+    journal: { ...spec.zero },
+  };
+  await writeState(ctx, spec, st, row?._id);
+  return token;
+}
+
+/** Read the next page of rows (scanPos, startTs], tally them into `scanned`,
+ *  and advance scanPos — atomically, so no concurrent change can fall between
+ *  "page read" and "boundary recorded". Returns whether the scan is complete.
+ *  Bounded: pageSize rows + the tail of a shared timestamp. */
+export async function scanCounterPage<C extends Record<string, number>, T extends TableNames>(
+  ctx: MutationCtx,
+  spec: CounterSpec<C, T>,
+  tally: (row: Doc<T>) => Partial<C>,
+  pageSize: number,
+): Promise<{ done: boolean; rows: number }> {
+  const row = await readRow(ctx.db, spec.key);
+  if (!row) return { done: true, rows: 0 };
+  const st = parseState(spec, row.value);
+  const rec = st.reconcile;
+  if (!rec || rec.scanPos >= rec.startTs) return { done: true, rows: 0 };
+  const page = await ctx.db
+    .query(spec.table)
+    // `as never`: over a generic table name TS cannot resolve `_creationTime`'s
+    // field type (it is `number` on every table); the values are plain numbers.
+    .withIndex('by_creation_time', (q) =>
+      q.gt('_creationTime', rec.scanPos as never).lte('_creationTime', rec.startTs as never),
+    )
+    .take(pageSize);
+  if (page.length === 0) {
+    rec.scanPos = rec.startTs;
+    await writeState(ctx, spec, st, row._id);
+    return { done: true, rows: 0 };
+  }
+  const last = page[page.length - 1]!._creationTime;
+  let rows: Doc<T>[] = page as Doc<T>[];
+  const full = page.length >= pageSize;
+  if (full) {
+    // Never leave part of a shared timestamp unscanned behind scanPos.
+    const twins = await ctx.db
+      .query(spec.table)
+      .withIndex('by_creation_time', (q) => q.eq('_creationTime', last as never))
+      .collect();
+    const seen = new Set(page.map((r) => r._id as string));
+    rows = rows.concat((twins as Doc<T>[]).filter((r) => !seen.has(r._id as string)));
+  }
+  for (const r of rows) {
+    for (const [k, d] of Object.entries(tally(r)) as [keyof C, number | undefined][]) {
+      if (d) rec.scanned[k] = (rec.scanned[k] + d) as C[keyof C];
+    }
+  }
+  const done = !full || last >= rec.startTs;
+  rec.scanPos = done ? rec.startTs : last;
+  await writeState(ctx, spec, st, row._id);
+  return { done, rows: rows.length };
+}
+
+/** Close the reconcile holding `token`: counts = scanned + journal, mark
+ *  initialized. Returns false (no write) when a newer reconcile superseded it
+ *  or the scan has not reached its boundary yet. */
+export async function finishCounterReconcile<
+  C extends Record<string, number>,
+  T extends TableNames,
+>(ctx: MutationCtx, spec: CounterSpec<C, T>, token: number): Promise<boolean> {
+  const row = await readRow(ctx.db, spec.key);
+  if (!row) return false;
+  const st = parseState(spec, row.value);
+  const rec = st.reconcile;
+  // Wrong token = a newer run superseded this one; scanPos short of the boundary
+  // = the scan is incomplete. Either way, writing would publish a partial count.
+  if (!rec || rec.token !== token || rec.scanPos < rec.startTs) return false;
+  const counts = { ...spec.zero };
+  for (const k of Object.keys(spec.zero) as (keyof C)[]) {
+    counts[k] = Math.max(0, rec.scanned[k] + rec.journal[k]) as C[keyof C];
+  }
+  await writeState(ctx, spec, { counts, initialized: true, runSeq: st.runSeq }, row._id);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Users: `stats:userCounts`
+// ---------------------------------------------------------------------------
 
 export const USER_COUNTS_KEY = 'stats:userCounts';
 
 export type UserStatusName = 'active' | 'grace' | 'disabled' | 'deleted' | 'inactive';
 
-export interface UserCounts {
+// `type` (not `interface`): an interface has no implicit index signature and
+// would not satisfy the generic `Record<string, number>` constraint above.
+export type UserCounts = {
   active: number;
   grace: number;
   disabled: number;
@@ -22,12 +313,12 @@ export interface UserCounts {
   /** Users whose last backend push failed and hasn't recovered (entitlement drift). */
   backendDrift: number;
   /** Active users on a default-free tier — the "free users helped" impact stat.
-   *  Maintained by the daily reconcile ONLY (a status delta doesn't know tier
-   *  membership); per-transition bumps preserve it via read-full/write-full. */
+   *  Maintained by the reconcile + `refreshFreeActive` ONLY (a status delta
+   *  doesn't know tier membership); per-transition bumps leave it alone. */
   freeActive: number;
-}
+};
 
-const ZERO: UserCounts = {
+export const ZERO_USER_COUNTS: UserCounts = {
   active: 0,
   grace: 0,
   disabled: 0,
@@ -37,27 +328,17 @@ const ZERO: UserCounts = {
   freeActive: 0,
 };
 
-export async function readUserCounts(db: DatabaseReader): Promise<UserCounts> {
-  const row = await db
-    .query('appState')
-    .withIndex('by_key', (q) => q.eq('key', USER_COUNTS_KEY))
-    .unique();
-  if (!row) return { ...ZERO };
-  try {
-    return { ...ZERO, ...(JSON.parse(row.value) as Partial<UserCounts>) };
-  } catch {
-    return { ...ZERO };
-  }
-}
+export const USER_COUNTER: CounterSpec<UserCounts, 'users'> = {
+  key: USER_COUNTS_KEY,
+  table: 'users',
+  zero: ZERO_USER_COUNTS,
+  // Prod rows predate the flag and were exact; nothing safety-critical reads it.
+  legacyInitialized: true,
+  createOnBump: true,
+};
 
-export async function writeUserCounts(ctx: MutationCtx, counts: UserCounts): Promise<void> {
-  const row = await ctx.db
-    .query('appState')
-    .withIndex('by_key', (q) => q.eq('key', USER_COUNTS_KEY))
-    .unique();
-  const value = JSON.stringify(counts);
-  if (row) await ctx.db.patch(row._id, { value, updatedAt: Date.now() });
-  else await ctx.db.insert('appState', { key: USER_COUNTS_KEY, value, updatedAt: Date.now() });
+export async function readUserCounts(db: DatabaseReader): Promise<UserCounts> {
+  return (await readCounter(db, USER_COUNTER)).counts;
 }
 
 /**
@@ -65,66 +346,53 @@ export async function writeUserCounts(ctx: MutationCtx, counts: UserCounts): Pro
  * (creation → only `statusTo`; hard-delete → only `statusFrom`). Reading `statusFrom`
  * from the row at the call site makes a no-op transition (from===to) self-cancel and
  * a re-applied transition idempotent. `driftDelta` bumps the backend-drift tally.
+ * `creationTime` = the user row's `_creationTime` (reconcile journal boundary).
  */
 export async function applyCountsDelta(
   ctx: MutationCtx,
-  d: { statusFrom?: UserStatusName | null; statusTo?: UserStatusName | null; driftDelta?: number },
+  d: {
+    statusFrom?: UserStatusName | null;
+    statusTo?: UserStatusName | null;
+    driftDelta?: number;
+    creationTime: number;
+  },
 ): Promise<void> {
-  const counts = await readUserCounts(ctx.db);
-  if (d.statusFrom) counts[d.statusFrom] = Math.max(0, counts[d.statusFrom] - 1);
-  if (d.statusTo) counts[d.statusTo] = Math.max(0, counts[d.statusTo] + 1);
-  if (d.driftDelta) counts.backendDrift = Math.max(0, counts.backendDrift + d.driftDelta);
-  await writeUserCounts(ctx, counts);
+  const delta: Partial<UserCounts> = {};
+  if (d.statusFrom) delta[d.statusFrom] = (delta[d.statusFrom] ?? 0) - 1;
+  if (d.statusTo) delta[d.statusTo] = (delta[d.statusTo] ?? 0) + 1;
+  if (d.driftDelta) delta.backendDrift = d.driftDelta;
+  await applyCounterDeltas(ctx, USER_COUNTER, [{ delta, creationTime: d.creationTime }]);
 }
 
-// === Session counter (2026-09-04 prod incident) =============================
-// `adminApi.statusSummary` used to `.collect()` every live session for the PoP
-// readiness tally; prod crossed Convex's per-execution read limit (32k docs) and
-// the whole endpoint 500-ed. Same cure as userCounts: one hot `appState` row
-// (`stats:sessionCounts`) bumped at every session insert/delete (all of which
-// live in sessions.ts + the lifecycle hard-delete cascade), rebuilt exactly by
-// `userStats.reconcileSessionCounts`. The counter tracks rows PRESENT, so a
-// session that silently ages past its TTL is counted until the (daily) sweep
-// deletes it — a conservative, bounded overstatement (≈ one day of expiries).
-//
-// Exactness under concurrency (review P1): a reconcile scan spans many
-// transactions, so a write landing mid-scan is ambiguous — is it already in the
-// scanned total or not? We remove the ambiguity by construction:
-//   • `begin` pins startTs = the newest session's _creationTime visible to it.
-//     Every later commit gets a larger _creationTime, so the scan (≤ startTs)
-//     covers a FIXED set of rows and a create during the scan is never in it.
-//   • While a reconcile is open, bumps for rows with _creationTime > startTs
-//     (all creates, and deletes of those creates) are ALSO recorded in a
-//     `journal`. Deletes of rows ≤ startTs are not journaled: the scan already
-//     accounts for them (absent if deleted before the page was read; present
-//     — a one-off overcount in the safe direction — if deleted after).
-//   • `finish` writes scanned + journal, replacing the live figures.
-// The row also carries `initialized` (review P2): until the first successful
-// reconcile the counts are unknown, statusSummary reports NOT ready, and bumps
-// on a missing row are no-ops (finish overwrites whatever they'd have built).
+// ---------------------------------------------------------------------------
+// Sessions: `stats:sessionCounts` (statusSummary's PoP readiness tally)
+// ---------------------------------------------------------------------------
 
 export const SESSION_COUNTS_KEY = 'stats:sessionCounts';
 
 export type SessionBucket = 'bound' | 'unboundMember' | 'unboundAdmin';
 
-export interface SessionCounts {
+export type SessionCounts = {
   /** PoP-bound sessions (member or admin) — a captured cookie alone can't replay. */
   bound: number;
   unboundMember: number;
   unboundAdmin: number;
-}
+};
 
 export const ZERO_SESSION_COUNTS: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
 
-/** Persisted shape of the `stats:sessionCounts` row's JSON value. */
-interface SessionCounterState extends SessionCounts {
-  /** False until the first reconcile finished (counts are meaningless before). */
-  initialized: boolean;
-  /** Present only while a reconcile is in flight (begin → finish). */
-  reconcile?: { startTs: number; journal: SessionCounts };
-}
+export const SESSION_COUNTER: CounterSpec<SessionCounts, 'sessions'> = {
+  key: SESSION_COUNTS_KEY,
+  table: 'sessions',
+  zero: ZERO_SESSION_COUNTS,
+  // `pop.readyToEnable` is a safety decision: unknown until the first reconcile.
+  legacyInitialized: false,
+  createOnBump: false,
+};
 
-/** Which counter bucket a session row belongs to. */
+/** Which counter bucket a session row belongs to. The counter tracks rows
+ *  PRESENT, so a session that silently ages past its TTL is counted until the
+ *  (daily) sweep deletes it — a conservative, bounded overstatement. */
 export function sessionBucket(row: {
   kind: 'member' | 'admin';
   popPublicKey?: string | undefined;
@@ -133,119 +401,31 @@ export function sessionBucket(row: {
   return row.kind === 'admin' ? 'unboundAdmin' : 'unboundMember';
 }
 
-function parseState(value: string): SessionCounterState {
-  try {
-    const raw = JSON.parse(value) as Partial<SessionCounterState>;
-    return {
-      ...ZERO_SESSION_COUNTS,
-      initialized: raw.initialized === true,
-      ...(raw.reconcile
-        ? {
-            reconcile: {
-              startTs: raw.reconcile.startTs,
-              journal: { ...ZERO_SESSION_COUNTS, ...raw.reconcile.journal },
-            },
-          }
-        : {}),
-      bound: raw.bound ?? 0,
-      unboundMember: raw.unboundMember ?? 0,
-      unboundAdmin: raw.unboundAdmin ?? 0,
-    };
-  } catch {
-    return { ...ZERO_SESSION_COUNTS, initialized: false };
-  }
-}
-
-async function readRow(db: DatabaseReader) {
-  return db
-    .query('appState')
-    .withIndex('by_key', (q) => q.eq('key', SESSION_COUNTS_KEY))
-    .unique();
-}
-
-async function writeState(ctx: MutationCtx, state: SessionCounterState): Promise<void> {
-  const row = await readRow(ctx.db);
-  const value = JSON.stringify(state);
-  if (row) await ctx.db.patch(row._id, { value, updatedAt: Date.now() });
-  else await ctx.db.insert('appState', { key: SESSION_COUNTS_KEY, value, updatedAt: Date.now() });
-}
-
-/** The live counts + whether they mean anything yet. Missing row ⇒ uninitialized
- *  zeros (statusSummary fails CLOSED on readiness until the first reconcile). */
 export async function readSessionCounts(
   db: DatabaseReader,
 ): Promise<{ counts: SessionCounts; initialized: boolean }> {
-  const row = await readRow(db);
-  if (!row) return { counts: { ...ZERO_SESSION_COUNTS }, initialized: false };
-  const st = parseState(row.value);
-  return {
-    counts: { bound: st.bound, unboundMember: st.unboundMember, unboundAdmin: st.unboundAdmin },
-    initialized: st.initialized,
-  };
+  return readCounter(db, SESSION_COUNTER);
 }
 
-/** One session row's contribution: its bucket + its _creationTime (the journal
- *  boundary test). `sign` = +1 for an insert, −1 for a delete. */
+/** One session row's contribution: its bucket + its `_creationTime`. */
 export interface SessionBump {
   bucket: SessionBucket;
   creationTime: number;
 }
 
-/** Apply inserts/deletes to the live counter inside the caller's transaction
- *  (clamped ≥ 0). No-op while the row doesn't exist yet — the first reconcile
- *  creates it. While a reconcile is open, rows newer than its startTs are also
- *  journaled (see the header). */
+/** +1 (insert) / −1 (delete) per row. Every session write path — sessions.ts +
+ *  the lifecycle hard-delete cascade — must call this. */
 export async function bumpSessionCounts(
   ctx: MutationCtx,
   rows: readonly SessionBump[],
   sign: 1 | -1,
 ): Promise<void> {
-  if (rows.length === 0) return;
-  const row = await readRow(ctx.db);
-  if (!row) return;
-  const st = parseState(row.value);
-  for (const r of rows) {
-    st[r.bucket] = Math.max(0, st[r.bucket] + sign);
-    if (st.reconcile && r.creationTime > st.reconcile.startTs) {
-      st.reconcile.journal[r.bucket] += sign;
-    }
-  }
-  await ctx.db.patch(row._id, { value: JSON.stringify(st), updatedAt: Date.now() });
-}
-
-/** Open a reconcile: pin the scan boundary + a fresh journal. Creates the row
- *  (uninitialized) when absent. Returns the boundary the scan must use
- *  (`_creationTime <= startTs`). A second `begin` while one is open simply
- *  supersedes it — the stale `finish` then sees a mismatched startTs and skips. */
-export async function beginSessionReconcile(ctx: MutationCtx): Promise<number> {
-  const newest = await ctx.db.query('sessions').order('desc').first();
-  const startTs = newest?._creationTime ?? 0;
-  const row = await readRow(ctx.db);
-  const st: SessionCounterState = row
-    ? parseState(row.value)
-    : { ...ZERO_SESSION_COUNTS, initialized: false };
-  st.reconcile = { startTs, journal: { ...ZERO_SESSION_COUNTS } };
-  await writeState(ctx, st);
-  return startTs;
-}
-
-/** Close the reconcile opened with `startTs`: live = scanned + journal, mark
- *  initialized. Returns false (no write) if another reconcile superseded it. */
-export async function finishSessionReconcile(
-  ctx: MutationCtx,
-  startTs: number,
-  scanned: SessionCounts,
-): Promise<boolean> {
-  const row = await readRow(ctx.db);
-  if (!row) return false;
-  const st = parseState(row.value);
-  if (!st.reconcile || st.reconcile.startTs !== startTs) return false;
-  const next: SessionCounterState = {
-    bound: Math.max(0, scanned.bound + st.reconcile.journal.bound),
-    unboundMember: Math.max(0, scanned.unboundMember + st.reconcile.journal.unboundMember),
-    unboundAdmin: Math.max(0, scanned.unboundAdmin + st.reconcile.journal.unboundAdmin),
-    initialized: true,
-  };
-  await ctx.db.patch(row._id, { value: JSON.stringify(next), updatedAt: Date.now() });
-  return true;
+  await applyCounterDeltas(
+    ctx,
+    SESSION_COUNTER,
+    rows.map((r) => ({
+      delta: { [r.bucket]: sign } as Partial<SessionCounts>,
+      creationTime: r.creationTime,
+    })),
+  );
 }

--- a/convex/lib/statusCounters.ts
+++ b/convex/lib/statusCounters.ts
@@ -86,6 +86,22 @@ export async function applyCountsDelta(
 // `userStats.reconcileSessionCounts`. The counter tracks rows PRESENT, so a
 // session that silently ages past its TTL is counted until the (daily) sweep
 // deletes it — a conservative, bounded overstatement (≈ one day of expiries).
+//
+// Exactness under concurrency (review P1): a reconcile scan spans many
+// transactions, so a write landing mid-scan is ambiguous — is it already in the
+// scanned total or not? We remove the ambiguity by construction:
+//   • `begin` pins startTs = the newest session's _creationTime visible to it.
+//     Every later commit gets a larger _creationTime, so the scan (≤ startTs)
+//     covers a FIXED set of rows and a create during the scan is never in it.
+//   • While a reconcile is open, bumps for rows with _creationTime > startTs
+//     (all creates, and deletes of those creates) are ALSO recorded in a
+//     `journal`. Deletes of rows ≤ startTs are not journaled: the scan already
+//     accounts for them (absent if deleted before the page was read; present
+//     — a one-off overcount in the safe direction — if deleted after).
+//   • `finish` writes scanned + journal, replacing the live figures.
+// The row also carries `initialized` (review P2): until the first successful
+// reconcile the counts are unknown, statusSummary reports NOT ready, and bumps
+// on a missing row are no-ops (finish overwrites whatever they'd have built).
 
 export const SESSION_COUNTS_KEY = 'stats:sessionCounts';
 
@@ -100,6 +116,14 @@ export interface SessionCounts {
 
 export const ZERO_SESSION_COUNTS: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
 
+/** Persisted shape of the `stats:sessionCounts` row's JSON value. */
+interface SessionCounterState extends SessionCounts {
+  /** False until the first reconcile finished (counts are meaningless before). */
+  initialized: boolean;
+  /** Present only while a reconcile is in flight (begin → finish). */
+  reconcile?: { startTs: number; journal: SessionCounts };
+}
+
 /** Which counter bucket a session row belongs to. */
 export function sessionBucket(row: {
   kind: 'member' | 'admin';
@@ -109,38 +133,119 @@ export function sessionBucket(row: {
   return row.kind === 'admin' ? 'unboundAdmin' : 'unboundMember';
 }
 
-export async function readSessionCounts(db: DatabaseReader): Promise<SessionCounts> {
-  const row = await db
-    .query('appState')
-    .withIndex('by_key', (q) => q.eq('key', SESSION_COUNTS_KEY))
-    .unique();
-  if (!row) return { ...ZERO_SESSION_COUNTS };
+function parseState(value: string): SessionCounterState {
   try {
-    return { ...ZERO_SESSION_COUNTS, ...(JSON.parse(row.value) as Partial<SessionCounts>) };
+    const raw = JSON.parse(value) as Partial<SessionCounterState>;
+    return {
+      ...ZERO_SESSION_COUNTS,
+      initialized: raw.initialized === true,
+      ...(raw.reconcile
+        ? {
+            reconcile: {
+              startTs: raw.reconcile.startTs,
+              journal: { ...ZERO_SESSION_COUNTS, ...raw.reconcile.journal },
+            },
+          }
+        : {}),
+      bound: raw.bound ?? 0,
+      unboundMember: raw.unboundMember ?? 0,
+      unboundAdmin: raw.unboundAdmin ?? 0,
+    };
   } catch {
-    return { ...ZERO_SESSION_COUNTS };
+    return { ...ZERO_SESSION_COUNTS, initialized: false };
   }
 }
 
-export async function writeSessionCounts(ctx: MutationCtx, counts: SessionCounts): Promise<void> {
-  const row = await ctx.db
+async function readRow(db: DatabaseReader) {
+  return db
     .query('appState')
     .withIndex('by_key', (q) => q.eq('key', SESSION_COUNTS_KEY))
     .unique();
-  const value = JSON.stringify(counts);
+}
+
+async function writeState(ctx: MutationCtx, state: SessionCounterState): Promise<void> {
+  const row = await readRow(ctx.db);
+  const value = JSON.stringify(state);
   if (row) await ctx.db.patch(row._id, { value, updatedAt: Date.now() });
   else await ctx.db.insert('appState', { key: SESSION_COUNTS_KEY, value, updatedAt: Date.now() });
 }
 
-/** Bump buckets by signed deltas inside the caller's transaction (clamped ≥ 0 so
- *  a pre-reconcile deployment never goes negative). A no-op for all-zero deltas. */
-export async function applySessionDelta(
+/** The live counts + whether they mean anything yet. Missing row ⇒ uninitialized
+ *  zeros (statusSummary fails CLOSED on readiness until the first reconcile). */
+export async function readSessionCounts(
+  db: DatabaseReader,
+): Promise<{ counts: SessionCounts; initialized: boolean }> {
+  const row = await readRow(db);
+  if (!row) return { counts: { ...ZERO_SESSION_COUNTS }, initialized: false };
+  const st = parseState(row.value);
+  return {
+    counts: { bound: st.bound, unboundMember: st.unboundMember, unboundAdmin: st.unboundAdmin },
+    initialized: st.initialized,
+  };
+}
+
+/** One session row's contribution: its bucket + its _creationTime (the journal
+ *  boundary test). `sign` = +1 for an insert, −1 for a delete. */
+export interface SessionBump {
+  bucket: SessionBucket;
+  creationTime: number;
+}
+
+/** Apply inserts/deletes to the live counter inside the caller's transaction
+ *  (clamped ≥ 0). No-op while the row doesn't exist yet — the first reconcile
+ *  creates it. While a reconcile is open, rows newer than its startTs are also
+ *  journaled (see the header). */
+export async function bumpSessionCounts(
   ctx: MutationCtx,
-  deltas: Partial<Record<SessionBucket, number>>,
+  rows: readonly SessionBump[],
+  sign: 1 | -1,
 ): Promise<void> {
-  const entries = Object.entries(deltas).filter(([, d]) => d !== 0) as [SessionBucket, number][];
-  if (entries.length === 0) return;
-  const counts = await readSessionCounts(ctx.db);
-  for (const [bucket, d] of entries) counts[bucket] = Math.max(0, counts[bucket] + d);
-  await writeSessionCounts(ctx, counts);
+  if (rows.length === 0) return;
+  const row = await readRow(ctx.db);
+  if (!row) return;
+  const st = parseState(row.value);
+  for (const r of rows) {
+    st[r.bucket] = Math.max(0, st[r.bucket] + sign);
+    if (st.reconcile && r.creationTime > st.reconcile.startTs) {
+      st.reconcile.journal[r.bucket] += sign;
+    }
+  }
+  await ctx.db.patch(row._id, { value: JSON.stringify(st), updatedAt: Date.now() });
+}
+
+/** Open a reconcile: pin the scan boundary + a fresh journal. Creates the row
+ *  (uninitialized) when absent. Returns the boundary the scan must use
+ *  (`_creationTime <= startTs`). A second `begin` while one is open simply
+ *  supersedes it — the stale `finish` then sees a mismatched startTs and skips. */
+export async function beginSessionReconcile(ctx: MutationCtx): Promise<number> {
+  const newest = await ctx.db.query('sessions').order('desc').first();
+  const startTs = newest?._creationTime ?? 0;
+  const row = await readRow(ctx.db);
+  const st: SessionCounterState = row
+    ? parseState(row.value)
+    : { ...ZERO_SESSION_COUNTS, initialized: false };
+  st.reconcile = { startTs, journal: { ...ZERO_SESSION_COUNTS } };
+  await writeState(ctx, st);
+  return startTs;
+}
+
+/** Close the reconcile opened with `startTs`: live = scanned + journal, mark
+ *  initialized. Returns false (no write) if another reconcile superseded it. */
+export async function finishSessionReconcile(
+  ctx: MutationCtx,
+  startTs: number,
+  scanned: SessionCounts,
+): Promise<boolean> {
+  const row = await readRow(ctx.db);
+  if (!row) return false;
+  const st = parseState(row.value);
+  if (!st.reconcile || st.reconcile.startTs !== startTs) return false;
+  const next: SessionCounterState = {
+    bound: Math.max(0, scanned.bound + st.reconcile.journal.bound),
+    unboundMember: Math.max(0, scanned.unboundMember + st.reconcile.journal.unboundMember),
+    unboundAdmin: Math.max(0, scanned.unboundAdmin + st.reconcile.journal.unboundAdmin),
+    initialized: true,
+  };
+  await ctx.db.patch(row._id, { value: JSON.stringify(next), updatedAt: Date.now() });
+  return true;
 }

--- a/convex/lib/statusCounters.ts
+++ b/convex/lib/statusCounters.ts
@@ -76,3 +76,71 @@ export async function applyCountsDelta(
   if (d.driftDelta) counts.backendDrift = Math.max(0, counts.backendDrift + d.driftDelta);
   await writeUserCounts(ctx, counts);
 }
+
+// === Session counter (2026-09-04 prod incident) =============================
+// `adminApi.statusSummary` used to `.collect()` every live session for the PoP
+// readiness tally; prod crossed Convex's per-execution read limit (32k docs) and
+// the whole endpoint 500-ed. Same cure as userCounts: one hot `appState` row
+// (`stats:sessionCounts`) bumped at every session insert/delete (all of which
+// live in sessions.ts + the lifecycle hard-delete cascade), rebuilt exactly by
+// `userStats.reconcileSessionCounts`. The counter tracks rows PRESENT, so a
+// session that silently ages past its TTL is counted until the (daily) sweep
+// deletes it — a conservative, bounded overstatement (≈ one day of expiries).
+
+export const SESSION_COUNTS_KEY = 'stats:sessionCounts';
+
+export type SessionBucket = 'bound' | 'unboundMember' | 'unboundAdmin';
+
+export interface SessionCounts {
+  /** PoP-bound sessions (member or admin) — a captured cookie alone can't replay. */
+  bound: number;
+  unboundMember: number;
+  unboundAdmin: number;
+}
+
+export const ZERO_SESSION_COUNTS: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
+
+/** Which counter bucket a session row belongs to. */
+export function sessionBucket(row: {
+  kind: 'member' | 'admin';
+  popPublicKey?: string | undefined;
+}): SessionBucket {
+  if (row.popPublicKey != null) return 'bound';
+  return row.kind === 'admin' ? 'unboundAdmin' : 'unboundMember';
+}
+
+export async function readSessionCounts(db: DatabaseReader): Promise<SessionCounts> {
+  const row = await db
+    .query('appState')
+    .withIndex('by_key', (q) => q.eq('key', SESSION_COUNTS_KEY))
+    .unique();
+  if (!row) return { ...ZERO_SESSION_COUNTS };
+  try {
+    return { ...ZERO_SESSION_COUNTS, ...(JSON.parse(row.value) as Partial<SessionCounts>) };
+  } catch {
+    return { ...ZERO_SESSION_COUNTS };
+  }
+}
+
+export async function writeSessionCounts(ctx: MutationCtx, counts: SessionCounts): Promise<void> {
+  const row = await ctx.db
+    .query('appState')
+    .withIndex('by_key', (q) => q.eq('key', SESSION_COUNTS_KEY))
+    .unique();
+  const value = JSON.stringify(counts);
+  if (row) await ctx.db.patch(row._id, { value, updatedAt: Date.now() });
+  else await ctx.db.insert('appState', { key: SESSION_COUNTS_KEY, value, updatedAt: Date.now() });
+}
+
+/** Bump buckets by signed deltas inside the caller's transaction (clamped ≥ 0 so
+ *  a pre-reconcile deployment never goes negative). A no-op for all-zero deltas. */
+export async function applySessionDelta(
+  ctx: MutationCtx,
+  deltas: Partial<Record<SessionBucket, number>>,
+): Promise<void> {
+  const entries = Object.entries(deltas).filter(([, d]) => d !== 0) as [SessionBucket, number][];
+  if (entries.length === 0) return;
+  const counts = await readSessionCounts(ctx.db);
+  for (const [bucket, d] of entries) counts[bucket] = Math.max(0, counts[bucket] + d);
+  await writeSessionCounts(ctx, counts);
+}

--- a/convex/lifecycle.ts
+++ b/convex/lifecycle.ts
@@ -25,7 +25,12 @@ import {
 import { resolveCurrentBonusGb } from './lib/donationBonus';
 import { SETTINGS_DEFAULTS } from './appSettings';
 import { writeAuditLog } from './lib/audit';
-import { applyCountsDelta } from './lib/statusCounters';
+import {
+  applyCountsDelta,
+  applySessionDelta,
+  sessionBucket,
+  type SessionBucket,
+} from './lib/statusCounters';
 import { resolvePlacementTarget } from './lib/remnawavePlacement';
 import { resolveDefaultFreeTier } from './tiers';
 import type { BackendId } from './lib/backendIds';
@@ -1092,12 +1097,7 @@ export const deleteInactiveUser = internalMutation({
     const u = await ctx.db.get(userId);
     if (!u || u.status !== 'inactive') return null;
     const deleteByUser = async (
-      table:
-        | 'subscriptions'
-        | 'tierHistory'
-        | 'billingOrders'
-        | 'memberPasskeyCredentials'
-        | 'sessions',
+      table: 'subscriptions' | 'tierHistory' | 'billingOrders' | 'memberPasskeyCredentials',
     ) => {
       const rows = await ctx.db
         .query(table)
@@ -1109,7 +1109,21 @@ export const deleteInactiveUser = internalMutation({
     await deleteByUser('tierHistory');
     await deleteByUser('billingOrders');
     await deleteByUser('memberPasskeyCredentials');
-    await deleteByUser('sessions');
+    // Sessions also feed the `stats:sessionCounts` counter (statusSummary's PoP
+    // tally) — decrement per deleted row like sessions.ts does.
+    {
+      const rows = await ctx.db
+        .query('sessions')
+        .withIndex('by_user', (q) => q.eq('userId', userId))
+        .collect();
+      const deltas: Partial<Record<SessionBucket, number>> = {};
+      for (const r of rows) {
+        await ctx.db.delete(r._id);
+        const b = sessionBucket(r);
+        deltas[b] = (deltas[b] ?? 0) - 1;
+      }
+      await applySessionDelta(ctx, deltas);
+    }
     // User-scoped fsv1_ tokens (subjectUserId): they resolve to null once the
     // user is gone (fail-closed), but don't leave the residue behind.
     const tokens = await ctx.db

--- a/convex/lifecycle.ts
+++ b/convex/lifecycle.ts
@@ -110,7 +110,11 @@ export async function applyMembership(ctx: MutationCtx, a: SetMembershipArgs): P
         updatedAt: Date.now(),
       });
       if (statusLifted)
-        await applyCountsDelta(ctx, { statusFrom: user.status, statusTo: 'active' });
+        await applyCountsDelta(ctx, {
+          statusFrom: user.status,
+          statusTo: 'active',
+          creationTime: user._creationTime,
+        });
       // Re-push so a same-tier renewal re-enables the backend key (the grace sweep
       // disabled it via setUserStatus(false)) and extends its expiry. Previously
       // this branch returned without a push, so the common monthly re-up left the
@@ -144,7 +148,11 @@ export async function applyMembership(ctx: MutationCtx, a: SetMembershipArgs): P
     updatedAt: Date.now(),
   });
   if (tierChangeLifts) {
-    await applyCountsDelta(ctx, { statusFrom: user.status, statusTo: 'active' });
+    await applyCountsDelta(ctx, {
+      statusFrom: user.status,
+      statusTo: 'active',
+      creationTime: user._creationTime,
+    });
   }
   await ctx.db.insert('tierHistory', {
     userId: a.userId,
@@ -437,7 +445,8 @@ export const recordPushFailure = internalMutation({
     const u = await ctx.db.get(userId);
     await ctx.db.patch(userId, { backendPushFailedAt: Date.now() });
     // Bump the drift tally only on the null→set transition (never double-count).
-    if (u && u.backendPushFailedAt == null) await applyCountsDelta(ctx, { driftDelta: 1 });
+    if (u && u.backendPushFailedAt == null)
+      await applyCountsDelta(ctx, { driftDelta: 1, creationTime: u._creationTime });
     return null;
   },
 });
@@ -454,11 +463,12 @@ export const setBackendDrift = internalMutation({
     const user = await ctx.db.get(userId);
     if (!user) return null;
     if (failed) {
-      if (user.backendPushFailedAt == null) await applyCountsDelta(ctx, { driftDelta: 1 });
+      if (user.backendPushFailedAt == null)
+        await applyCountsDelta(ctx, { driftDelta: 1, creationTime: user._creationTime });
       await ctx.db.patch(userId, { backendPushFailedAt: Date.now() });
     } else if (user.backendPushFailedAt != null) {
       await ctx.db.patch(userId, { backendPushFailedAt: undefined });
-      await applyCountsDelta(ctx, { driftDelta: -1 });
+      await applyCountsDelta(ctx, { driftDelta: -1, creationTime: user._creationTime });
     }
     return null;
   },
@@ -541,7 +551,11 @@ export const applyGraceTransition = internalMutation({
       return null;
     }
     await ctx.db.patch(userId, { status: 'grace', updatedAt: Date.now() });
-    await applyCountsDelta(ctx, { statusFrom: u.status, statusTo: 'grace' });
+    await applyCountsDelta(ctx, {
+      statusFrom: u.status,
+      statusTo: 'grace',
+      creationTime: u._creationTime,
+    });
     await writeAuditLog(ctx, {
       actorType: 'system',
       action: 'membership.transition.grace',
@@ -571,7 +585,11 @@ export const applyDisableTransition = internalMutation({
       suspendedAt: Date.now(),
       updatedAt: Date.now(),
     });
-    await applyCountsDelta(ctx, { statusFrom: u.status, statusTo: 'disabled' });
+    await applyCountsDelta(ctx, {
+      statusFrom: u.status,
+      statusTo: 'disabled',
+      creationTime: u._creationTime,
+    });
     await writeAuditLog(ctx, {
       actorType: 'system',
       action: 'membership.transition.disabled',
@@ -898,7 +916,11 @@ export const markUserInactive = internalMutation({
       suspendedAt: Date.now(),
       updatedAt: Date.now(),
     });
-    await applyCountsDelta(ctx, { statusFrom: 'active', statusTo: 'inactive' });
+    await applyCountsDelta(ctx, {
+      statusFrom: 'active',
+      statusTo: 'inactive',
+      creationTime: u._creationTime,
+    });
     await writeAuditLog(ctx, {
       actorType: 'system',
       action: 'membership.transition.inactive',
@@ -930,7 +952,11 @@ export const refreshFreeWindow = internalMutation({
     }
     await ctx.db.patch(userId, patch);
     if (reactivating) {
-      await applyCountsDelta(ctx, { statusFrom: 'inactive', statusTo: 'active' });
+      await applyCountsDelta(ctx, {
+        statusFrom: 'inactive',
+        statusTo: 'active',
+        creationTime: u._creationTime,
+      });
       await writeAuditLog(ctx, {
         actorType: 'system',
         action: 'account.reactivate',
@@ -1143,6 +1169,7 @@ export const deleteInactiveUser = internalMutation({
     await applyCountsDelta(ctx, {
       statusFrom: 'inactive',
       driftDelta: u.backendPushFailedAt != null ? -1 : 0,
+      creationTime: u._creationTime,
     });
     await ctx.db.delete(userId);
     return null;

--- a/convex/lifecycle.ts
+++ b/convex/lifecycle.ts
@@ -27,9 +27,9 @@ import { SETTINGS_DEFAULTS } from './appSettings';
 import { writeAuditLog } from './lib/audit';
 import {
   applyCountsDelta,
-  applySessionDelta,
+  bumpSessionCounts,
   sessionBucket,
-  type SessionBucket,
+  type SessionBump,
 } from './lib/statusCounters';
 import { resolvePlacementTarget } from './lib/remnawavePlacement';
 import { resolveDefaultFreeTier } from './tiers';
@@ -1116,13 +1116,12 @@ export const deleteInactiveUser = internalMutation({
         .query('sessions')
         .withIndex('by_user', (q) => q.eq('userId', userId))
         .collect();
-      const deltas: Partial<Record<SessionBucket, number>> = {};
+      const bumps: SessionBump[] = [];
       for (const r of rows) {
         await ctx.db.delete(r._id);
-        const b = sessionBucket(r);
-        deltas[b] = (deltas[b] ?? 0) - 1;
+        bumps.push({ bucket: sessionBucket(r), creationTime: r._creationTime });
       }
-      await applySessionDelta(ctx, deltas);
+      await bumpSessionCounts(ctx, bumps, -1);
     }
     // User-scoped fsv1_ tokens (subjectUserId): they resolve to null once the
     // user is gone (fail-closed), but don't leave the residue behind.

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -331,6 +331,8 @@ export default defineSchema({
     // Instance→subs reference check before a backend-server delete (refuse
     // while keys still point at it).
     .index('by_backend_server', ['backendServerId'])
+    // Bounded "any live key on this panel?" probe for the instance-delete guard.
+    .index('by_backend_server_state', ['backendServerId', 'state'])
     // The FCP-fronted subscription route resolves the sub by its opaque token.
     .index('by_sub_token', ['subToken']),
 

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -6,10 +6,16 @@
  *
  * `bySid` treats an expired row as absent (defence-in-depth alongside the daily
  * sweep), so a stale-but-unswept cookie never authenticates.
+ *
+ * Every insert/delete here ALSO bumps the `stats:sessionCounts` counter
+ * (lib/statusCounters.ts) that `adminApi.statusSummary` reads for the PoP
+ * readiness tally — keep that invariant when adding a write path (the only
+ * other one is the lifecycle hard-delete cascade).
  */
 import { internalMutation, internalQuery } from './_generated/server';
 import { internal } from './_generated/api';
 import { recordHeartbeat } from './cronHeartbeat';
+import { applySessionDelta, sessionBucket, type SessionBucket } from './lib/statusCounters';
 import { ConvexError } from 'convex/values';
 import { v } from 'convex/values';
 import { b64UrlToBytes } from '../src/shared/crypto/envelope';
@@ -80,6 +86,7 @@ export const create = internalMutation({
       expiresAt: Date.now() + ttlMs,
       ...(bound ? { popPublicKey, popAlg: boundAlg, popSessionToken } : {}),
     });
+    await applySessionDelta(ctx, { [sessionBucket({ kind, popPublicKey })]: 1 });
     return null;
   },
 });
@@ -103,7 +110,10 @@ export const deleteBySid = internalMutation({
       .query('sessions')
       .withIndex('by_sid', (q) => q.eq('sid', sid))
       .unique();
-    if (row) await ctx.db.delete(row._id);
+    if (row) {
+      await ctx.db.delete(row._id);
+      await applySessionDelta(ctx, { [sessionBucket(row)]: -1 });
+    }
     return null;
   },
 });
@@ -123,11 +133,15 @@ export const deleteAllForUserExcept = internalMutation({
       .withIndex('by_user', (q) => q.eq('userId', userId))
       .collect();
     let removed = 0;
+    const deltas: Partial<Record<SessionBucket, number>> = {};
     for (const row of rows) {
       if (keepSid !== undefined && row.sid === keepSid) continue;
       await ctx.db.delete(row._id);
+      const b = sessionBucket(row);
+      deltas[b] = (deltas[b] ?? 0) - 1;
       removed++;
     }
+    await applySessionDelta(ctx, deltas);
     return { removed };
   },
 });
@@ -145,7 +159,13 @@ export const sweepExpired = internalMutation({
       .query('sessions')
       .withIndex('by_expires', (q) => q.lt('expiresAt', now))
       .take(page);
-    for (const row of expired) await ctx.db.delete(row._id);
+    const deltas: Partial<Record<SessionBucket, number>> = {};
+    for (const row of expired) {
+      await ctx.db.delete(row._id);
+      const b = sessionBucket(row);
+      deltas[b] = (deltas[b] ?? 0) - 1;
+    }
+    await applySessionDelta(ctx, deltas);
     if (expired.length === page) {
       const n = rounds ?? 0;
       if (n >= MAX_DRAIN_ROUNDS) console.warn('[session-sweep] drain cap hit; remainder next run');

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -15,7 +15,7 @@
 import { internalMutation, internalQuery } from './_generated/server';
 import { internal } from './_generated/api';
 import { recordHeartbeat } from './cronHeartbeat';
-import { applySessionDelta, sessionBucket, type SessionBucket } from './lib/statusCounters';
+import { bumpSessionCounts, sessionBucket, type SessionBump } from './lib/statusCounters';
 import { ConvexError } from 'convex/values';
 import { v } from 'convex/values';
 import { b64UrlToBytes } from '../src/shared/crypto/envelope';
@@ -78,7 +78,7 @@ export const create = internalMutation({
       .withIndex('by_sid', (q) => q.eq('sid', sid))
       .unique();
     if (clash) throw new Error('session sid collision');
-    await ctx.db.insert('sessions', {
+    const id = await ctx.db.insert('sessions', {
       sid,
       kind,
       userId,
@@ -86,7 +86,14 @@ export const create = internalMutation({
       expiresAt: Date.now() + ttlMs,
       ...(bound ? { popPublicKey, popAlg: boundAlg, popSessionToken } : {}),
     });
-    await applySessionDelta(ctx, { [sessionBucket({ kind, popPublicKey })]: 1 });
+    // Counter bump keyed on the row's own _creationTime (the reconcile journal
+    // boundary) — read it back rather than assume Date.now() matches.
+    const inserted = await ctx.db.get(id);
+    await bumpSessionCounts(
+      ctx,
+      [{ bucket: sessionBucket({ kind, popPublicKey }), creationTime: inserted!._creationTime }],
+      1,
+    );
     return null;
   },
 });
@@ -112,7 +119,11 @@ export const deleteBySid = internalMutation({
       .unique();
     if (row) {
       await ctx.db.delete(row._id);
-      await applySessionDelta(ctx, { [sessionBucket(row)]: -1 });
+      await bumpSessionCounts(
+        ctx,
+        [{ bucket: sessionBucket(row), creationTime: row._creationTime }],
+        -1,
+      );
     }
     return null;
   },
@@ -133,15 +144,14 @@ export const deleteAllForUserExcept = internalMutation({
       .withIndex('by_user', (q) => q.eq('userId', userId))
       .collect();
     let removed = 0;
-    const deltas: Partial<Record<SessionBucket, number>> = {};
+    const bumps: SessionBump[] = [];
     for (const row of rows) {
       if (keepSid !== undefined && row.sid === keepSid) continue;
       await ctx.db.delete(row._id);
-      const b = sessionBucket(row);
-      deltas[b] = (deltas[b] ?? 0) - 1;
+      bumps.push({ bucket: sessionBucket(row), creationTime: row._creationTime });
       removed++;
     }
-    await applySessionDelta(ctx, deltas);
+    await bumpSessionCounts(ctx, bumps, -1);
     return { removed };
   },
 });
@@ -159,13 +169,12 @@ export const sweepExpired = internalMutation({
       .query('sessions')
       .withIndex('by_expires', (q) => q.lt('expiresAt', now))
       .take(page);
-    const deltas: Partial<Record<SessionBucket, number>> = {};
+    const bumps: SessionBump[] = [];
     for (const row of expired) {
       await ctx.db.delete(row._id);
-      const b = sessionBucket(row);
-      deltas[b] = (deltas[b] ?? 0) - 1;
+      bumps.push({ bucket: sessionBucket(row), creationTime: row._creationTime });
     }
-    await applySessionDelta(ctx, deltas);
+    await bumpSessionCounts(ctx, bumps, -1);
     if (expired.length === page) {
       const n = rounds ?? 0;
       if (n >= MAX_DRAIN_ROUNDS) console.warn('[session-sweep] drain cap hit; remainder next run');

--- a/convex/userStats.test.ts
+++ b/convex/userStats.test.ts
@@ -8,7 +8,7 @@ import { convexTest } from 'convex-test';
 import { describe, expect, test } from 'vitest';
 import schema from './schema';
 import { internal } from './_generated/api';
-import { readUserCounts, applyCountsDelta } from './lib/statusCounters';
+import { readUserCounts } from './lib/statusCounters';
 import type { Id } from './_generated/dataModel';
 
 const modules = import.meta.glob('./**/*.*s');
@@ -71,34 +71,95 @@ describe('userStats counters (WS3)', () => {
     expect(await t.action(internal.userStats.reconcileUserCounts, {})).toEqual(c1);
   });
 
-  test('the delta write preserves transitions that landed mid-scan', async () => {
+  // The old live+(scanned−baseline) delta write double-applied a change that
+  // landed before the scan reached its row (review P1 on the session counter;
+  // the user counter had the same flaw). The begin/scan/finish protocol is
+  // exact in every ordering — pinned here with a 1-row page so the scan can be
+  // interleaved with transitions deterministically.
+  test('reconcile is exact when a transition races the scan (either side of scanPos)', async () => {
+    const t = convexTest(schema, modules);
+    const tierId = await seedFreeTier(t);
+    const [u1, u2, u3] = await t.run(async (ctx) => {
+      const mk = () => ctx.db.insert('users', { tierId, status: 'active', updatedAt: Date.now() });
+      return [await mk(), await mk(), await mk()];
+    });
+    await t.action(internal.userStats.reconcileUserCounts, {});
+    expect(await counts(t)).toMatchObject({ active: 3, grace: 0, disabled: 0 });
+    const freeTierIds = [tierId];
+
+    const startTs = await t.mutation(internal.userStats.beginUserCountsReconcile, {});
+    // Page 1 scans u1 (oldest) → scanPos = u1. Then u1 transitions: the scan saw
+    // it ACTIVE, so the change must be journaled (c ≤ scanPos).
+    expect(
+      (await t.mutation(internal.userStats.scanUserCountsPage, { freeTierIds, pageSize: 1 })).done,
+    ).toBe(false);
+    await t.mutation(internal.adminApi.disableUser, { userId: u1! });
+    // u3 (not yet scanned) transitions: the scan will see it DISABLED, so the
+    // change must NOT be journaled (c > scanPos).
+    await t.mutation(internal.adminApi.disableUser, { userId: u3! });
+    // A user created mid-scan (c > startTs): outside the scan set → journaled.
+    await t.mutation(internal.freeTier.createFreeUser, { tierId });
+    for (let i = 0; i < 10; i++) {
+      const r = await t.mutation(internal.userStats.scanUserCountsPage, {
+        freeTierIds,
+        pageSize: 1,
+      });
+      if (r.done) break;
+    }
+    expect(await t.mutation(internal.userStats.finishUserCountsReconcile, { token: startTs })).toBe(
+      true,
+    );
+    // u2 + the new user active, u1 + u3 disabled — every change applied exactly once.
+    expect(await counts(t)).toMatchObject({ active: 2, disabled: 2, grace: 0 });
+    // And a fresh reconcile agrees (no drift was introduced).
+    expect(await t.action(internal.userStats.reconcileUserCounts, {})).toMatchObject({
+      active: 2,
+      disabled: 2,
+    });
+    void u2;
+  });
+
+  test('a superseded user reconcile does not write', async () => {
     const t = convexTest(schema, modules);
     const tierId = await seedFreeTier(t);
     await t.run((ctx) =>
       ctx.db.insert('users', { tierId, status: 'active', updatedAt: Date.now() }),
     );
     await t.action(internal.userStats.reconcileUserCounts, {});
-    const live = await counts(t);
-    expect(live.active).toBe(1);
+    const stale = await t.mutation(internal.userStats.beginUserCountsReconcile, {});
+    await t.mutation(internal.userStats.beginUserCountsReconcile, {}); // newer run
+    expect(await t.mutation(internal.userStats.finishUserCountsReconcile, { token: stale })).toBe(
+      false,
+    );
+    expect((await counts(t)).active).toBe(1);
+  });
 
-    // Simulate a mid-scan race: the baseline was taken at live=1, the scan's
-    // exact total also reads 1 (it raced BEFORE the transitioning row), but a
-    // transition bumped the live row to 2 meanwhile. next = live + (scan − base)
-    // = 2 + (1 − 1) = 2 — the bump survives; an absolute write would lose it.
-    await t.run((ctx) => applyCountsDelta(ctx, { statusTo: 'active' }));
-    expect((await counts(t)).active).toBe(2);
-    await t.mutation(internal.userStats.applyReconcileDelta, {
-      baseline: { ...live },
-      scanned: { ...live },
+  test('a page boundary never splits a shared _creationTime', async () => {
+    // Rows inserted in ONE transaction share _creationTime. With pageSize=2 the
+    // first page would end inside that group; the scan must pull the rest of
+    // the timestamp in so scanPos stays exact.
+    const t = convexTest(schema, modules);
+    const tierId = await seedFreeTier(t);
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 5; i++) {
+        await ctx.db.insert('users', { tierId, status: 'grace', updatedAt: Date.now() });
+      }
     });
-    expect((await counts(t)).active).toBe(2);
-
-    // And the ≥0 clamp holds when a decrement races BOTH the scan and the write.
-    await t.mutation(internal.userStats.applyReconcileDelta, {
-      baseline: { ...live, active: 50 },
-      scanned: { ...live, active: 0 },
-    });
-    expect((await counts(t)).active).toBeGreaterThanOrEqual(0);
+    const startTs = await t.mutation(internal.userStats.beginUserCountsReconcile, {});
+    let pages = 0;
+    for (let i = 0; i < 10; i++) {
+      pages++;
+      const r = await t.mutation(internal.userStats.scanUserCountsPage, {
+        freeTierIds: [tierId],
+        pageSize: 2,
+      });
+      if (r.done) break;
+    }
+    expect(await t.mutation(internal.userStats.finishUserCountsReconcile, { token: startTs })).toBe(
+      true,
+    );
+    expect((await counts(t)).grace).toBe(5);
+    expect(pages).toBeLessThanOrEqual(5);
   });
 
   test('grace/disable transitions move the buckets', async () => {
@@ -243,6 +304,13 @@ describe('userStats counters (WS3)', () => {
 describe('session counter reconcile (2026-09-04)', () => {
   const live = async (t: ReturnType<typeof convexTest>) =>
     (await t.query(internal.userStats.getSessionCounts, {})).counts;
+  const scanAll = async (t: ReturnType<typeof convexTest>, pageSize = 500) => {
+    for (let i = 0; i < 50; i++) {
+      const r = await t.mutation(internal.userStats.scanSessionCountsPage, { pageSize });
+      if (r.done) return;
+    }
+    throw new Error('scan did not finish');
+  };
 
   test('a delete racing the scan is applied exactly once (review P1 scenario)', async () => {
     // Two unbound sessions; the reconcile begins; one is deleted BEFORE its page
@@ -257,16 +325,28 @@ describe('session counter reconcile (2026-09-04)', () => {
 
     const startTs = await t.mutation(internal.userStats.beginSessionCountsReconcile, {});
     await t.mutation(internal.sessions.deleteBySid, { sid: 'a' }); // before the scan reads it
-    const page = await t.query(internal.userStats.tallySessionCountsPage, {
-      startTs,
-      cursor: null,
-      numItems: 500,
-    });
-    expect(page.counts.unboundMember).toBe(1); // scan sees the post-delete table
-    await t.mutation(internal.userStats.finishSessionCountsReconcile, {
-      startTs,
-      scanned: page.counts,
-    });
+    await scanAll(t);
+    expect(
+      await t.mutation(internal.userStats.finishSessionCountsReconcile, { token: startTs }),
+    ).toBe(true);
+    expect((await live(t)).unboundMember).toBe(1);
+  });
+
+  test('a delete of an ALREADY-scanned row is journaled (exact, not an overcount)', async () => {
+    const t = convexTest(schema, modules);
+    await t.action(internal.userStats.reconcileSessionCounts, {});
+    await t.mutation(internal.sessions.create, { sid: 'a', kind: 'member', ttlMs: 60_000 });
+    await t.mutation(internal.sessions.create, { sid: 'b', kind: 'member', ttlMs: 60_000 });
+    const startTs = await t.mutation(internal.userStats.beginSessionCountsReconcile, {});
+    // Page of 1 scans 'a' (oldest); then 'a' is deleted → journal −1.
+    expect((await t.mutation(internal.userStats.scanSessionCountsPage, { pageSize: 1 })).done).toBe(
+      false,
+    );
+    await t.mutation(internal.sessions.deleteBySid, { sid: 'a' });
+    await scanAll(t, 1);
+    expect(
+      await t.mutation(internal.userStats.finishSessionCountsReconcile, { token: startTs }),
+    ).toBe(true);
     expect((await live(t)).unboundMember).toBe(1);
   });
 
@@ -280,16 +360,10 @@ describe('session counter reconcile (2026-09-04)', () => {
     await t.mutation(internal.sessions.create, { sid: 'new-1', kind: 'admin', ttlMs: 60_000 });
     await t.mutation(internal.sessions.create, { sid: 'new-2', kind: 'admin', ttlMs: 60_000 });
     await t.mutation(internal.sessions.deleteBySid, { sid: 'new-2' }); // journal nets to +1 admin
-    const page = await t.query(internal.userStats.tallySessionCountsPage, {
-      startTs,
-      cursor: null,
-      numItems: 500,
-    });
-    expect(page.counts).toEqual({ bound: 0, unboundMember: 1, unboundAdmin: 0 }); // only 'old'
-    await t.mutation(internal.userStats.finishSessionCountsReconcile, {
-      startTs,
-      scanned: page.counts,
-    });
+    await scanAll(t);
+    expect(
+      await t.mutation(internal.userStats.finishSessionCountsReconcile, { token: startTs }),
+    ).toBe(true);
     expect(await live(t)).toEqual({ bound: 0, unboundMember: 1, unboundAdmin: 1 });
   });
 
@@ -300,11 +374,9 @@ describe('session counter reconcile (2026-09-04)', () => {
     const stale = await t.mutation(internal.userStats.beginSessionCountsReconcile, {});
     await t.mutation(internal.sessions.create, { sid: 'y', kind: 'member', ttlMs: 60_000 });
     await t.mutation(internal.userStats.beginSessionCountsReconcile, {}); // newer run
-    const applied = await t.mutation(internal.userStats.finishSessionCountsReconcile, {
-      startTs: stale,
-      scanned: { bound: 0, unboundMember: 0, unboundAdmin: 0 },
-    });
-    expect(applied).toBe(false);
+    expect(
+      await t.mutation(internal.userStats.finishSessionCountsReconcile, { token: stale }),
+    ).toBe(false);
     expect((await live(t)).unboundMember).toBe(2); // live bumps untouched
   });
 

--- a/convex/userStats.test.ts
+++ b/convex/userStats.test.ts
@@ -239,3 +239,94 @@ describe('userStats counters (WS3)', () => {
     expect((await counts(t)).backendDrift).toBe(0);
   });
 });
+
+describe('session counter reconcile (2026-09-04)', () => {
+  const live = async (t: ReturnType<typeof convexTest>) =>
+    (await t.query(internal.userStats.getSessionCounts, {})).counts;
+
+  test('a delete racing the scan is applied exactly once (review P1 scenario)', async () => {
+    // Two unbound sessions; the reconcile begins; one is deleted BEFORE its page
+    // is scanned. The old live+(scanned−baseline) formula wrote 0 here (live=1,
+    // scanned=1, baseline=2) and statusSummary would have reported "safe to
+    // enable". Correct answer: 1.
+    const t = convexTest(schema, modules);
+    await t.action(internal.userStats.reconcileSessionCounts, {}); // initialize
+    await t.mutation(internal.sessions.create, { sid: 'a', kind: 'member', ttlMs: 60_000 });
+    await t.mutation(internal.sessions.create, { sid: 'b', kind: 'member', ttlMs: 60_000 });
+    expect((await live(t)).unboundMember).toBe(2);
+
+    const startTs = await t.mutation(internal.userStats.beginSessionCountsReconcile, {});
+    await t.mutation(internal.sessions.deleteBySid, { sid: 'a' }); // before the scan reads it
+    const page = await t.query(internal.userStats.tallySessionCountsPage, {
+      startTs,
+      cursor: null,
+      numItems: 500,
+    });
+    expect(page.counts.unboundMember).toBe(1); // scan sees the post-delete table
+    await t.mutation(internal.userStats.finishSessionCountsReconcile, {
+      startTs,
+      scanned: page.counts,
+    });
+    expect((await live(t)).unboundMember).toBe(1);
+  });
+
+  test('creates (and deletes of those creates) during the scan are journaled, not lost', async () => {
+    const t = convexTest(schema, modules);
+    await t.action(internal.userStats.reconcileSessionCounts, {});
+    await t.mutation(internal.sessions.create, { sid: 'old', kind: 'member', ttlMs: 60_000 });
+
+    const startTs = await t.mutation(internal.userStats.beginSessionCountsReconcile, {});
+    // Land after the boundary: excluded from the scan, carried by the journal.
+    await t.mutation(internal.sessions.create, { sid: 'new-1', kind: 'admin', ttlMs: 60_000 });
+    await t.mutation(internal.sessions.create, { sid: 'new-2', kind: 'admin', ttlMs: 60_000 });
+    await t.mutation(internal.sessions.deleteBySid, { sid: 'new-2' }); // journal nets to +1 admin
+    const page = await t.query(internal.userStats.tallySessionCountsPage, {
+      startTs,
+      cursor: null,
+      numItems: 500,
+    });
+    expect(page.counts).toEqual({ bound: 0, unboundMember: 1, unboundAdmin: 0 }); // only 'old'
+    await t.mutation(internal.userStats.finishSessionCountsReconcile, {
+      startTs,
+      scanned: page.counts,
+    });
+    expect(await live(t)).toEqual({ bound: 0, unboundMember: 1, unboundAdmin: 1 });
+  });
+
+  test('a superseded reconcile does not write', async () => {
+    const t = convexTest(schema, modules);
+    await t.action(internal.userStats.reconcileSessionCounts, {});
+    await t.mutation(internal.sessions.create, { sid: 'x', kind: 'member', ttlMs: 60_000 });
+    const stale = await t.mutation(internal.userStats.beginSessionCountsReconcile, {});
+    await t.mutation(internal.sessions.create, { sid: 'y', kind: 'member', ttlMs: 60_000 });
+    await t.mutation(internal.userStats.beginSessionCountsReconcile, {}); // newer run
+    const applied = await t.mutation(internal.userStats.finishSessionCountsReconcile, {
+      startTs: stale,
+      scanned: { bound: 0, unboundMember: 0, unboundAdmin: 0 },
+    });
+    expect(applied).toBe(false);
+    expect((await live(t)).unboundMember).toBe(2); // live bumps untouched
+  });
+
+  test('full reconcile is exact + idempotent and flips initialized', async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 7; i++) {
+        await ctx.db.insert('sessions', {
+          sid: `s-${i}`,
+          kind: i % 2 ? 'admin' : 'member',
+          expiresAt: Date.now() + 60_000,
+          ...(i === 0 ? { popPublicKey: 'A'.repeat(43), popAlg: 'EdDSA' } : {}),
+        });
+      }
+    });
+    expect((await t.query(internal.userStats.getSessionCounts, {})).initialized).toBe(false);
+    const total = await t.action(internal.userStats.reconcileSessionCounts, {});
+    expect(total).toEqual({ bound: 1, unboundMember: 3, unboundAdmin: 3 });
+    const again = await t.action(internal.userStats.reconcileSessionCounts, {});
+    expect(again).toEqual(total);
+    const st = await t.query(internal.userStats.getSessionCounts, {});
+    expect(st.initialized).toBe(true);
+    expect(st.counts).toEqual(total);
+  });
+});

--- a/convex/userStats.ts
+++ b/convex/userStats.ts
@@ -1,8 +1,10 @@
 /**
- * User-status counter reconcile (M2 / WS3). `reconcileUserCounts` recomputes the
- * `appState` counter row (statusCounters.ts) exactly by a paginated full scan —
- * bounded per page so it never trips the per-query read limit — and self-heals any
- * drift from a missed transition bump. Run daily by cron + once post-deploy.
+ * Counter reconciles (M2 / WS3 + 2026-09-04). Both `appState` counters that feed
+ * `adminApi.statusSummary` — `stats:userCounts` and `stats:sessionCounts` — are
+ * rebuilt exactly by the begin → scan pages → finish protocol in
+ * lib/statusCounters.ts (bounded per page so it never trips the per-execution
+ * read limit; exact under concurrent writes via the pinned boundary + journal).
+ * Run daily by cron + once post-deploy.
  */
 import { internalAction, internalMutation, internalQuery } from './_generated/server';
 import { internal } from './_generated/api';
@@ -10,83 +12,57 @@ import type { Id } from './_generated/dataModel';
 import { v } from 'convex/values';
 import { runWithCronOutcome } from './cronHeartbeat';
 import {
-  beginSessionReconcile,
-  finishSessionReconcile,
+  SESSION_COUNTER,
+  USER_COUNTER,
+  beginCounterReconcile,
+  finishCounterReconcile,
+  patchCounterCounts,
   readSessionCounts,
   readUserCounts,
+  scanCounterPage,
   sessionBucket,
-  writeUserCounts,
   type SessionCounts,
   type UserCounts,
 } from './lib/statusCounters';
 
-const COUNTS_VALIDATOR = v.object({
-  active: v.number(),
-  grace: v.number(),
-  disabled: v.number(),
-  deleted: v.number(),
-  inactive: v.number(),
-  backendDrift: v.number(),
-  freeActive: v.number(),
+const PAGE = 500;
+
+// === Users ===================================================================
+
+export const beginUserCountsReconcile = internalMutation({
+  args: {},
+  handler: async (ctx): Promise<number> => beginCounterReconcile(ctx, USER_COUNTER),
 });
 
-/** Tally one page of users (bounded read) → partial counts + the paginate cursor.
- *  `freeTierIds` = the default-free tier set; active users on one count toward
- *  `freeActive` (the "free users helped" impact stat). */
-export const tallyUserCountsPage = internalQuery({
-  args: {
-    cursor: v.union(v.string(), v.null()),
-    numItems: v.number(),
-    freeTierIds: v.array(v.id('tiers')),
-  },
-  handler: async (ctx, { cursor, numItems, freeTierIds }) => {
-    const res = await ctx.db.query('users').paginate({ cursor, numItems });
+/** Scan one page of users (bounded read) into the open reconcile. `freeTierIds`
+ *  = the default-free tier set; active users on one count toward `freeActive`. */
+export const scanUserCountsPage = internalMutation({
+  args: { freeTierIds: v.array(v.id('tiers')), pageSize: v.optional(v.number()) },
+  handler: async (ctx, { freeTierIds, pageSize }) => {
     const freeIdSet = new Set<string>(freeTierIds);
-    const counts: UserCounts = {
-      active: 0,
-      grace: 0,
-      disabled: 0,
-      deleted: 0,
-      inactive: 0,
-      backendDrift: 0,
-      freeActive: 0,
-    };
-    for (const u of res.page) {
-      counts[u.status] += 1;
-      if (u.backendPushFailedAt != null) counts.backendDrift += 1;
-      if (u.status === 'active' && freeIdSet.has(u.tierId)) counts.freeActive += 1;
-    }
-    return { counts, isDone: res.isDone, continueCursor: res.continueCursor };
+    return scanCounterPage(
+      ctx,
+      USER_COUNTER,
+      (u) => ({
+        [u.status]: 1,
+        ...(u.backendPushFailedAt != null ? { backendDrift: 1 } : {}),
+        ...(u.status === 'active' && freeIdSet.has(u.tierId) ? { freeActive: 1 } : {}),
+      }),
+      pageSize ?? PAGE,
+    );
   },
 });
 
-/** The counter row as it currently stands (the reconcile baseline). */
+export const finishUserCountsReconcile = internalMutation({
+  args: { token: v.number() },
+  handler: async (ctx, { token }): Promise<boolean> =>
+    finishCounterReconcile(ctx, USER_COUNTER, token),
+});
+
+/** The counter row as it currently stands. */
 export const getUserCounts = internalQuery({
   args: {},
   handler: async (ctx): Promise<UserCounts> => readUserCounts(ctx.db),
-});
-
-/**
- * Apply the reconcile result as a DELTA against the live row, not an absolute
- * write: status transitions landing mid-scan bump the live counter via
- * applyCountsDelta, and an absolute overwrite would silently discard those
- * bumps (up to 24h of drift from the daily "self-heal" itself). next =
- * live + (scanned − baseline); when nothing changed mid-scan this equals the
- * exact scanned total, and the residual error is bounded to transitions that
- * raced the scan rather than compounding them. Clamped ≥ 0 (a transition can
- * legitimately race both the scan AND this write).
- */
-export const applyReconcileDelta = internalMutation({
-  args: { baseline: COUNTS_VALIDATOR, scanned: COUNTS_VALIDATOR },
-  handler: async (ctx, { baseline, scanned }) => {
-    const live = await readUserCounts(ctx.db);
-    const next = { ...live };
-    for (const k of Object.keys(scanned) as (keyof UserCounts)[]) {
-      next[k] = Math.max(0, live[k] + (scanned[k] - baseline[k]));
-    }
-    await writeUserCounts(ctx, next);
-    return null;
-  },
 });
 
 /** One page of ACTIVE users on a free tier (index prefix scan) — the targeted
@@ -106,13 +82,12 @@ export const countFreeActivePage = internalQuery({
   },
 });
 
-/** Overwrite ONLY the freeActive field of the live counter row (read-full/
- *  write-full, so concurrent status-transition bumps to other fields are kept). */
+/** Overwrite ONLY the freeActive field of the live counter row (the other
+ *  fields + any open reconcile's state are preserved). */
 export const setFreeActive = internalMutation({
   args: { freeActive: v.number() },
   handler: async (ctx, { freeActive }) => {
-    const live = await readUserCounts(ctx.db);
-    await writeUserCounts(ctx, { ...live, freeActive: Math.max(0, freeActive) });
+    await patchCounterCounts(ctx, USER_COUNTER, { freeActive: Math.max(0, freeActive) });
     return null;
   },
 });
@@ -124,9 +99,8 @@ export const setFreeActive = internalMutation({
  * — freeActive is otherwise maintained only by the DAILY full reconcile (a
  * status transition can't bump it: it doesn't know tier membership), which
  * stays as the self-healing backstop. Deliberately not the full
- * reconcileUserCounts: this scan is bounded to free users, touches no other
- * counter field, and two concurrent runs converge on the same exact value
- * (the full reconcile's delta-write can transiently corrupt under a race).
+ * reconcileUserCounts: this scan is bounded to free users and touches no other
+ * counter field.
  */
 export const refreshFreeActive = internalAction({
   args: {},
@@ -138,7 +112,7 @@ export const refreshFreeActive = internalAction({
       for (let i = 0; i < 100_000; i++) {
         const res: { count: number; isDone: boolean; continueCursor: string } = await ctx.runQuery(
           internal.userStats.countFreeActivePage,
-          { tierId, cursor, numItems: 500 },
+          { tierId, cursor, numItems: PAGE },
         );
         freeActive += res.count;
         if (res.isDone) break;
@@ -150,82 +124,47 @@ export const refreshFreeActive = internalAction({
   },
 });
 
-/** Recompute the counter row from scratch (idempotent, self-healing). */
+/** Recompute the user counter row from scratch (idempotent, self-healing). */
 export const reconcileUserCounts = internalAction({
   args: {},
   handler: async (ctx): Promise<UserCounts> =>
     runWithCronOutcome(ctx, 'user-counts-reconcile', async () => {
       const freeTierIds: Id<'tiers'>[] = await ctx.runQuery(internal.tiers.defaultFreeTierIds, {});
-      // Baseline BEFORE the scan: transitions after this point bump the live row
-      // and are preserved by the delta write (see applyReconcileDelta).
-      const baseline = await ctx.runQuery(internal.userStats.getUserCounts, {});
-      const total: UserCounts = {
-        active: 0,
-        grace: 0,
-        disabled: 0,
-        deleted: 0,
-        inactive: 0,
-        backendDrift: 0,
-        freeActive: 0,
-      };
-      let cursor: string | null = null;
+      const token: number = await ctx.runMutation(internal.userStats.beginUserCountsReconcile, {});
       for (let i = 0; i < 100_000; i++) {
-        // Annotated to break the same-module self-referential inference.
-        const res: { counts: UserCounts; isDone: boolean; continueCursor: string } =
-          await ctx.runQuery(internal.userStats.tallyUserCountsPage, {
-            cursor,
-            numItems: 500,
-            freeTierIds,
-          });
-        for (const k of Object.keys(total) as (keyof UserCounts)[]) total[k] += res.counts[k];
-        if (res.isDone) break;
-        cursor = res.continueCursor;
+        const res: { done: boolean; rows: number } = await ctx.runMutation(
+          internal.userStats.scanUserCountsPage,
+          { freeTierIds },
+        );
+        if (res.done) break;
       }
-      await ctx.runMutation(internal.userStats.applyReconcileDelta, {
-        baseline,
-        scanned: total,
+      const applied: boolean = await ctx.runMutation(internal.userStats.finishUserCountsReconcile, {
+        token,
       });
-      return total;
+      if (!applied) console.warn('[user-counts-reconcile] superseded by a newer run; skipped');
+      return await ctx.runQuery(internal.userStats.getUserCounts, {});
     }),
 });
 
-// === Session counter reconcile (2026-09-04) ==================================
-// Exact under concurrency (see the statusCounters.ts header): `begin` pins the
-// scan boundary (newest visible _creationTime) and opens a delta journal; the
-// scan pages over the FIXED set of rows at or before that boundary; `finish`
-// writes scanned + journal. Counts rows PRESENT (expired-but-unswept included)
-// to match what the per-write bumps track; the daily session-sweep decrements
-// as it deletes.
-
-const SESSION_COUNTS_VALIDATOR = v.object({
-  bound: v.number(),
-  unboundMember: v.number(),
-  unboundAdmin: v.number(),
-});
+// === Sessions ================================================================
+// Counts rows PRESENT (expired-but-unswept included) to match what the per-write
+// bumps track; the daily session-sweep decrements as it deletes.
 
 export const beginSessionCountsReconcile = internalMutation({
   args: {},
-  handler: async (ctx): Promise<number> => beginSessionReconcile(ctx),
+  handler: async (ctx): Promise<number> => beginCounterReconcile(ctx, SESSION_COUNTER),
 });
 
-/** Tally one page of the sessions created at or before the pinned boundary. */
-export const tallySessionCountsPage = internalQuery({
-  args: { startTs: v.number(), cursor: v.union(v.string(), v.null()), numItems: v.number() },
-  handler: async (ctx, { startTs, cursor, numItems }) => {
-    const res = await ctx.db
-      .query('sessions')
-      .withIndex('by_creation_time', (q) => q.lte('_creationTime', startTs))
-      .paginate({ cursor, numItems });
-    const counts: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
-    for (const row of res.page) counts[sessionBucket(row)] += 1;
-    return { counts, isDone: res.isDone, continueCursor: res.continueCursor };
-  },
+export const scanSessionCountsPage = internalMutation({
+  args: { pageSize: v.optional(v.number()) },
+  handler: async (ctx, { pageSize }) =>
+    scanCounterPage(ctx, SESSION_COUNTER, (row) => ({ [sessionBucket(row)]: 1 }), pageSize ?? PAGE),
 });
 
 export const finishSessionCountsReconcile = internalMutation({
-  args: { startTs: v.number(), scanned: SESSION_COUNTS_VALIDATOR },
-  handler: async (ctx, { startTs, scanned }): Promise<boolean> =>
-    finishSessionReconcile(ctx, startTs, scanned),
+  args: { token: v.number() },
+  handler: async (ctx, { token }): Promise<boolean> =>
+    finishCounterReconcile(ctx, SESSION_COUNTER, token),
 });
 
 export const getSessionCounts = internalQuery({
@@ -241,28 +180,26 @@ export const reconcileSessionCounts = internalAction({
   args: {},
   handler: async (ctx): Promise<SessionCounts> =>
     runWithCronOutcome(ctx, 'session-counts-reconcile', async () => {
-      const startTs: number = await ctx.runMutation(
+      const token: number = await ctx.runMutation(
         internal.userStats.beginSessionCountsReconcile,
         {},
       );
-      const total: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
-      let cursor: string | null = null;
       for (let i = 0; i < 100_000; i++) {
-        const res: { counts: SessionCounts; isDone: boolean; continueCursor: string } =
-          await ctx.runQuery(internal.userStats.tallySessionCountsPage, {
-            startTs,
-            cursor,
-            numItems: 500,
-          });
-        for (const k of Object.keys(total) as (keyof SessionCounts)[]) total[k] += res.counts[k];
-        if (res.isDone) break;
-        cursor = res.continueCursor;
+        const res: { done: boolean; rows: number } = await ctx.runMutation(
+          internal.userStats.scanSessionCountsPage,
+          {},
+        );
+        if (res.done) break;
       }
       const applied: boolean = await ctx.runMutation(
         internal.userStats.finishSessionCountsReconcile,
-        { startTs, scanned: total },
+        { token },
       );
       if (!applied) console.warn('[session-counts-reconcile] superseded by a newer run; skipped');
-      return total;
+      const st: { counts: SessionCounts; initialized: boolean } = await ctx.runQuery(
+        internal.userStats.getSessionCounts,
+        {},
+      );
+      return st.counts;
     }),
 });

--- a/convex/userStats.ts
+++ b/convex/userStats.ts
@@ -10,10 +10,11 @@ import type { Id } from './_generated/dataModel';
 import { v } from 'convex/values';
 import { runWithCronOutcome } from './cronHeartbeat';
 import {
+  beginSessionReconcile,
+  finishSessionReconcile,
   readSessionCounts,
   readUserCounts,
   sessionBucket,
-  writeSessionCounts,
   writeUserCounts,
   type SessionCounts,
   type UserCounts,
@@ -189,10 +190,12 @@ export const reconcileUserCounts = internalAction({
 });
 
 // === Session counter reconcile (2026-09-04) ==================================
-// Same shape as the user-counts reconcile: paginated full scan → delta write
-// against the live row so logins/logouts landing mid-scan are preserved. Counts
-// rows PRESENT (expired-but-unswept included) to match what the per-write bumps
-// track; the daily session-sweep decrements as it deletes.
+// Exact under concurrency (see the statusCounters.ts header): `begin` pins the
+// scan boundary (newest visible _creationTime) and opens a delta journal; the
+// scan pages over the FIXED set of rows at or before that boundary; `finish`
+// writes scanned + journal. Counts rows PRESENT (expired-but-unswept included)
+// to match what the per-write bumps track; the daily session-sweep decrements
+// as it deletes.
 
 const SESSION_COUNTS_VALIDATOR = v.object({
   bound: v.number(),
@@ -200,56 +203,66 @@ const SESSION_COUNTS_VALIDATOR = v.object({
   unboundAdmin: v.number(),
 });
 
-/** Tally one page of sessions (bounded read). */
+export const beginSessionCountsReconcile = internalMutation({
+  args: {},
+  handler: async (ctx): Promise<number> => beginSessionReconcile(ctx),
+});
+
+/** Tally one page of the sessions created at or before the pinned boundary. */
 export const tallySessionCountsPage = internalQuery({
-  args: { cursor: v.union(v.string(), v.null()), numItems: v.number() },
-  handler: async (ctx, { cursor, numItems }) => {
-    const res = await ctx.db.query('sessions').paginate({ cursor, numItems });
+  args: { startTs: v.number(), cursor: v.union(v.string(), v.null()), numItems: v.number() },
+  handler: async (ctx, { startTs, cursor, numItems }) => {
+    const res = await ctx.db
+      .query('sessions')
+      .withIndex('by_creation_time', (q) => q.lte('_creationTime', startTs))
+      .paginate({ cursor, numItems });
     const counts: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
     for (const row of res.page) counts[sessionBucket(row)] += 1;
     return { counts, isDone: res.isDone, continueCursor: res.continueCursor };
   },
 });
 
-export const getSessionCounts = internalQuery({
-  args: {},
-  handler: async (ctx): Promise<SessionCounts> => readSessionCounts(ctx.db),
+export const finishSessionCountsReconcile = internalMutation({
+  args: { startTs: v.number(), scanned: SESSION_COUNTS_VALIDATOR },
+  handler: async (ctx, { startTs, scanned }): Promise<boolean> =>
+    finishSessionReconcile(ctx, startTs, scanned),
 });
 
-export const applySessionReconcileDelta = internalMutation({
-  args: { baseline: SESSION_COUNTS_VALIDATOR, scanned: SESSION_COUNTS_VALIDATOR },
-  handler: async (ctx, { baseline, scanned }) => {
-    const live = await readSessionCounts(ctx.db);
-    const next = { ...live };
-    for (const k of Object.keys(scanned) as (keyof SessionCounts)[]) {
-      next[k] = Math.max(0, live[k] + (scanned[k] - baseline[k]));
-    }
-    await writeSessionCounts(ctx, next);
-    return null;
-  },
+export const getSessionCounts = internalQuery({
+  args: {},
+  handler: async (ctx) => readSessionCounts(ctx.db),
 });
 
 /** Recompute the session counter row from scratch (idempotent, self-healing).
  *  Daily cron + once post-deploy (the deploy entrypoint); the row is built from
- *  nothing on the first run after this shipped. */
+ *  nothing on the first run after this shipped, and `statusSummary` reports the
+ *  readiness flag as NOT ready until that first run completes. */
 export const reconcileSessionCounts = internalAction({
   args: {},
   handler: async (ctx): Promise<SessionCounts> =>
     runWithCronOutcome(ctx, 'session-counts-reconcile', async () => {
-      const baseline: SessionCounts = await ctx.runQuery(internal.userStats.getSessionCounts, {});
+      const startTs: number = await ctx.runMutation(
+        internal.userStats.beginSessionCountsReconcile,
+        {},
+      );
       const total: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
       let cursor: string | null = null;
       for (let i = 0; i < 100_000; i++) {
         const res: { counts: SessionCounts; isDone: boolean; continueCursor: string } =
-          await ctx.runQuery(internal.userStats.tallySessionCountsPage, { cursor, numItems: 500 });
+          await ctx.runQuery(internal.userStats.tallySessionCountsPage, {
+            startTs,
+            cursor,
+            numItems: 500,
+          });
         for (const k of Object.keys(total) as (keyof SessionCounts)[]) total[k] += res.counts[k];
         if (res.isDone) break;
         cursor = res.continueCursor;
       }
-      await ctx.runMutation(internal.userStats.applySessionReconcileDelta, {
-        baseline,
-        scanned: total,
-      });
+      const applied: boolean = await ctx.runMutation(
+        internal.userStats.finishSessionCountsReconcile,
+        { startTs, scanned: total },
+      );
+      if (!applied) console.warn('[session-counts-reconcile] superseded by a newer run; skipped');
       return total;
     }),
 });

--- a/convex/userStats.ts
+++ b/convex/userStats.ts
@@ -9,7 +9,15 @@ import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { v } from 'convex/values';
 import { runWithCronOutcome } from './cronHeartbeat';
-import { readUserCounts, writeUserCounts, type UserCounts } from './lib/statusCounters';
+import {
+  readSessionCounts,
+  readUserCounts,
+  sessionBucket,
+  writeSessionCounts,
+  writeUserCounts,
+  type SessionCounts,
+  type UserCounts,
+} from './lib/statusCounters';
 
 const COUNTS_VALIDATOR = v.object({
   active: v.number(),
@@ -173,6 +181,72 @@ export const reconcileUserCounts = internalAction({
         cursor = res.continueCursor;
       }
       await ctx.runMutation(internal.userStats.applyReconcileDelta, {
+        baseline,
+        scanned: total,
+      });
+      return total;
+    }),
+});
+
+// === Session counter reconcile (2026-09-04) ==================================
+// Same shape as the user-counts reconcile: paginated full scan → delta write
+// against the live row so logins/logouts landing mid-scan are preserved. Counts
+// rows PRESENT (expired-but-unswept included) to match what the per-write bumps
+// track; the daily session-sweep decrements as it deletes.
+
+const SESSION_COUNTS_VALIDATOR = v.object({
+  bound: v.number(),
+  unboundMember: v.number(),
+  unboundAdmin: v.number(),
+});
+
+/** Tally one page of sessions (bounded read). */
+export const tallySessionCountsPage = internalQuery({
+  args: { cursor: v.union(v.string(), v.null()), numItems: v.number() },
+  handler: async (ctx, { cursor, numItems }) => {
+    const res = await ctx.db.query('sessions').paginate({ cursor, numItems });
+    const counts: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
+    for (const row of res.page) counts[sessionBucket(row)] += 1;
+    return { counts, isDone: res.isDone, continueCursor: res.continueCursor };
+  },
+});
+
+export const getSessionCounts = internalQuery({
+  args: {},
+  handler: async (ctx): Promise<SessionCounts> => readSessionCounts(ctx.db),
+});
+
+export const applySessionReconcileDelta = internalMutation({
+  args: { baseline: SESSION_COUNTS_VALIDATOR, scanned: SESSION_COUNTS_VALIDATOR },
+  handler: async (ctx, { baseline, scanned }) => {
+    const live = await readSessionCounts(ctx.db);
+    const next = { ...live };
+    for (const k of Object.keys(scanned) as (keyof SessionCounts)[]) {
+      next[k] = Math.max(0, live[k] + (scanned[k] - baseline[k]));
+    }
+    await writeSessionCounts(ctx, next);
+    return null;
+  },
+});
+
+/** Recompute the session counter row from scratch (idempotent, self-healing).
+ *  Daily cron + once post-deploy (the deploy entrypoint); the row is built from
+ *  nothing on the first run after this shipped. */
+export const reconcileSessionCounts = internalAction({
+  args: {},
+  handler: async (ctx): Promise<SessionCounts> =>
+    runWithCronOutcome(ctx, 'session-counts-reconcile', async () => {
+      const baseline: SessionCounts = await ctx.runQuery(internal.userStats.getSessionCounts, {});
+      const total: SessionCounts = { bound: 0, unboundMember: 0, unboundAdmin: 0 };
+      let cursor: string | null = null;
+      for (let i = 0; i < 100_000; i++) {
+        const res: { counts: SessionCounts; isDone: boolean; continueCursor: string } =
+          await ctx.runQuery(internal.userStats.tallySessionCountsPage, { cursor, numItems: 500 });
+        for (const k of Object.keys(total) as (keyof SessionCounts)[]) total[k] += res.counts[k];
+        if (res.isDone) break;
+        cursor = res.continueCursor;
+      }
+      await ctx.runMutation(internal.userStats.applySessionReconcileDelta, {
         baseline,
         scanned: total,
       });

--- a/docker/deploy-entrypoint.sh
+++ b/docker/deploy-entrypoint.sh
@@ -117,6 +117,10 @@ bunx convex run seed:seedCutover '{}'
 # Idempotent; also self-healed by a daily cron.
 echo "[deploy] reconciling the user-status counter"
 bunx convex run userStats:reconcileUserCounts '{}'
+# Same for the session counter (statusSummary's PoP readiness tally): builds the
+# row from nothing on the first deploy that ships it, self-heals after.
+echo "[deploy] reconciling the session counter"
+bunx convex run userStats:reconcileSessionCounts '{}'
 
 echo "[deploy] OK"
 # First-run reminder: the first admin registers a passkey at /admin using the

--- a/docs/project-inventory.md
+++ b/docs/project-inventory.md
@@ -581,5 +581,9 @@ Traffic-scaled tables (never `collect()` them without a selective index range): 
 Patterns that are safe: `take(page)` + drain-chain (the sweeps), `paginate()` (admin lists,
 reconciles), `first()` on a compound index (`assertBackendServerUnused`), or a **maintained
 counter** in `appState` bumped at every transition + a daily paginated reconcile
-(`stats:userCounts`, `stats:sessionCounts` in `convex/lib/statusCounters.ts`). Two incidents
+(`stats:userCounts`, `stats:sessionCounts` in `convex/lib/statusCounters.ts`). The session
+reconcile is exact under concurrent writes: `begin` pins the scan boundary at the newest
+visible `_creationTime` and opens a delta journal for rows newer than it, `finish` writes
+scanned + journal; the row also carries `initialized`, and `statusSummary` reports PoP
+readiness as unknown (never "safe") until the first reconcile has completed. Two incidents
 so far: the users tally (2026-06, M2/WS3) and the live-sessions PoP tally (2026-09-04).

--- a/docs/project-inventory.md
+++ b/docs/project-inventory.md
@@ -581,9 +581,11 @@ Traffic-scaled tables (never `collect()` them without a selective index range): 
 Patterns that are safe: `take(page)` + drain-chain (the sweeps), `paginate()` (admin lists,
 reconciles), `first()` on a compound index (`assertBackendServerUnused`), or a **maintained
 counter** in `appState` bumped at every transition + a daily paginated reconcile
-(`stats:userCounts`, `stats:sessionCounts` in `convex/lib/statusCounters.ts`). The session
-reconcile is exact under concurrent writes: `begin` pins the scan boundary at the newest
-visible `_creationTime` and opens a delta journal for rows newer than it, `finish` writes
-scanned + journal; the row also carries `initialized`, and `statusSummary` reports PoP
-readiness as unknown (never "safe") until the first reconcile has completed. Two incidents
+(`stats:userCounts`, `stats:sessionCounts` in `convex/lib/statusCounters.ts`). Both reconciles
+share one protocol that is exact under concurrent writes: `begin` pins the scan boundary at
+the newest visible `_creationTime`; each page is read and its `scanPos` recorded in the same
+mutation; a change on a row the scan has already read (or will never read) is journaled,
+one the scan has yet to read is not; `finish` writes scanned + journal. The session row also
+carries `initialized`, and `statusSummary` reports PoP readiness as unknown (never "safe")
+until the first reconcile has completed. Two incidents
 so far: the users tally (2026-06, M2/WS3) and the live-sessions PoP tally (2026-09-04).

--- a/docs/project-inventory.md
+++ b/docs/project-inventory.md
@@ -469,6 +469,8 @@ Convex runs these natively (no Workers triggers, no node-cron):
 - `deactivate-idle-free` (daily 03:00 UTC): deactivate + RETAIN idle free users (reclaim key →
   `status:'inactive'`; paginated over `by_tier_status_freekey`). Never deletes.
 - `user-counts-reconcile` (daily 04:00 UTC): recompute the `appState` user-status counter (self-heal).
+- `session-counts-reconcile` (daily 04:10 UTC): recompute the `appState` session counter behind
+  the admin dashboard's PoP readiness tally (self-heal; bumped live on every session write).
 - `session-sweep` / `rate-limit-sweep` / `replay-guard-sweep` (daily): drop expired
   `sessions` / `rateLimits` / `replayGuard` rows.
 - `epoch-key-rotate` (10 min) / `epoch-key-sweep` (daily): CDN-blinding HPKE epoch keys.
@@ -563,3 +565,21 @@ When you flip something Deferred/Dormant → Live, enable a dormant feature, or 
 retire a scaffold, update the relevant row here in the same change, and record resolved
 security/bug items in the operator's private audit tracker. The companion docs hold
 the detail; this file is the index.
+
+## Read-limit rule (Convex per-execution cap)
+
+A single query/mutation execution can read at most **32,000 documents / 8 MiB** on the
+pinned self-hosted backend, and there is no knob to raise it. Any `.collect()` (or
+filter-then-first) over a table that grows with traffic eventually throws, and because
+`REDACT_LOGS_TO_CLIENT` is on, the caller only sees `Server Error` — even the admin CLI
+(`bunx convex run`). Read the real message with `bunx convex logs --history 30` via the
+deployer container (`docs/beta-deploy.md` § One-off functions).
+
+Traffic-scaled tables (never `collect()` them without a selective index range): `users`,
+`sessions`, `subscriptions`, `tierHistory`, `auditLog`, `billingOrders`, `webhookEvents`,
+`redemptionCodes`, `referrals`, `rateLimits`, `replayGuard`, the WebAuthn challenge tables.
+Patterns that are safe: `take(page)` + drain-chain (the sweeps), `paginate()` (admin lists,
+reconciles), `first()` on a compound index (`assertBackendServerUnused`), or a **maintained
+counter** in `appState` bumped at every transition + a daily paginated reconcile
+(`stats:userCounts`, `stats:sessionCounts` in `convex/lib/statusCounters.ts`). Two incidents
+so far: the users tally (2026-06, M2/WS3) and the live-sessions PoP tally (2026-09-04).

--- a/docs/threat-model-cdn-blinding.md
+++ b/docs/threat-model-cdn-blinding.md
@@ -119,8 +119,10 @@ sessions that predate PoP or that belong to a client which could not enroll a ke
   (`adminApi.statusSummary.pop`) reports `bound / activeSessions` and the remaining cookie-only
   count, split member vs admin. The tally is read from the maintained `stats:sessionCounts`
   counter (`convex/lib/statusCounters.ts`, bumped by every session insert/delete, rebuilt daily
-  by `userStats.reconcileSessionCounts`) — an unbounded scan of live sessions 500-ed the endpoint
-  on prod once they passed Convex's 32k-document read limit (2026-09-04). It reads
+  by `userStats.reconcileSessionCounts` with a pinned scan boundary + delta journal so racing
+  writes are applied exactly once) — an unbounded scan of live sessions 500-ed the endpoint
+  on prod once they passed Convex's 32k-document read limit (2026-09-04). Until the first
+  reconcile has run (`pop.initialized`), readiness reads as unknown, never "safe". It reads
   **"Safe to enable"** exactly when `readyToEnable` is true
   (zero unbound active sessions) — nothing would be logged out. Watch it until it stays at zero
   across a full session-TTL window. A count that never reaches zero means a real client keeps

--- a/docs/threat-model-cdn-blinding.md
+++ b/docs/threat-model-cdn-blinding.md
@@ -119,8 +119,8 @@ sessions that predate PoP or that belong to a client which could not enroll a ke
   (`adminApi.statusSummary.pop`) reports `bound / activeSessions` and the remaining cookie-only
   count, split member vs admin. The tally is read from the maintained `stats:sessionCounts`
   counter (`convex/lib/statusCounters.ts`, bumped by every session insert/delete, rebuilt daily
-  by `userStats.reconcileSessionCounts` with a pinned scan boundary + delta journal so racing
-  writes are applied exactly once) — an unbounded scan of live sessions 500-ed the endpoint
+  by `userStats.reconcileSessionCounts` with a pinned scan boundary, per-page `scanPos` and a
+  delta journal so racing writes are applied exactly once) — an unbounded scan of live sessions 500-ed the endpoint
   on prod once they passed Convex's 32k-document read limit (2026-09-04). Until the first
   reconcile has run (`pop.initialized`), readiness reads as unknown, never "safe". It reads
   **"Safe to enable"** exactly when `readyToEnable` is true

--- a/docs/threat-model-cdn-blinding.md
+++ b/docs/threat-model-cdn-blinding.md
@@ -117,7 +117,11 @@ sessions that predate PoP or that belong to a client which could not enroll a ke
 
 - **Readiness is observed, not timed.** The admin dashboard's _Session protection_ card
   (`adminApi.statusSummary.pop`) reports `bound / activeSessions` and the remaining cookie-only
-  count, split member vs admin. It reads **"Safe to enable"** exactly when `readyToEnable` is true
+  count, split member vs admin. The tally is read from the maintained `stats:sessionCounts`
+  counter (`convex/lib/statusCounters.ts`, bumped by every session insert/delete, rebuilt daily
+  by `userStats.reconcileSessionCounts`) — an unbounded scan of live sessions 500-ed the endpoint
+  on prod once they passed Convex's 32k-document read limit (2026-09-04). It reads
+  **"Safe to enable"** exactly when `readyToEnable` is true
   (zero unbound active sessions) — nothing would be logged out. Watch it until it stays at zero
   across a full session-TTL window. A count that never reaches zero means a real client keeps
   logging in without enrolling a key (no WebCrypto / IndexedDB) — those clients **will** be locked

--- a/src/client/lib/queries.ts
+++ b/src/client/lib/queries.ts
@@ -303,6 +303,9 @@ export const adminStatusQuery = () =>
     queryKey: queryKeys.adminStatus,
     queryFn: () => apiClient.get('/api/v1/admin/status', AdminStatusSummary),
     staleTime: 15_000,
+    // The user/session figures are maintained counters (live to the last
+    // transition), so polling is cheap: O(1) reads + the small admin tables.
+    refetchInterval: 30_000,
   }));
 
 export const adminTiersQuery = () =>

--- a/src/client/routes/admin/AdminDashboard.svelte
+++ b/src/client/routes/admin/AdminDashboard.svelte
@@ -196,10 +196,18 @@
         <CardTitle class="text-lg">Session protection (proof-of-possession)</CardTitle>
       </CardHeader>
       <CardContent class="space-y-2 text-sm">
-        <p class="text-muted-foreground">
-          {s.pop.bound}/{s.pop.activeSessions} active sessions are key-bound - a captured cookie alone
-          cannot be replayed.
-        </p>
+        {#if !s.pop.initialized}
+          <p class="text-muted-foreground">
+            Session figures are not available yet: the session counter is built by the post-deploy
+            reconcile (or the daily <code class="font-mono">session-counts-reconcile</code> job). Readiness
+            is reported as unknown until it has run once.
+          </p>
+        {:else}
+          <p class="text-muted-foreground">
+            {s.pop.bound}/{s.pop.activeSessions} active sessions are key-bound - a captured cookie alone
+            cannot be replayed.
+          </p>
+        {/if}
         {#if s.pop.required}
           <div
             class="flex items-center gap-2.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-emerald-700 dark:text-emerald-300"
@@ -207,6 +215,11 @@
             <CheckCircle class="size-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
             <span>Enforced - cookie-only sessions are rejected (POP_REQUIRED is on).</span>
           </div>
+        {:else if !s.pop.initialized}
+          <p class="text-muted-foreground">
+            Cannot judge whether <code class="font-mono">POP_REQUIRED</code> is safe to enable until the
+            counter exists.
+          </p>
         {:else if s.pop.readyToEnable}
           <div
             class="flex items-center gap-2.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-emerald-700 dark:text-emerald-300"

--- a/src/shared/contracts/admin.ts
+++ b/src/shared/contracts/admin.ts
@@ -515,6 +515,10 @@ export const AdminStatusSummary = z.object({
       unboundMember: z.number().int().nonnegative(),
       unboundAdmin: z.number().int().nonnegative(),
       readyToEnable: z.boolean(),
+      /** False until the session counter's first reconcile has run: the counts
+       *  are unknown and readyToEnable is forced false. Additive default true
+       *  (a pre-counter backend computed exact figures). */
+      initialized: z.boolean().default(true),
     })
     .default({
       required: false,
@@ -524,6 +528,7 @@ export const AdminStatusSummary = z.object({
       unboundMember: 0,
       unboundAdmin: 0,
       readyToEnable: false,
+      initialized: true,
     }),
   // CDN-blinding E2EE posture: FS_E2EE_REQUIRED rejects unsealed member
   // requests on seal/reveal routes. Additive default for a pre-deploy backend.


### PR DESCRIPTION
## Incident

`GET /api/v1/admin/status` on prod returned `{"code":"[Request ID: …] Server Error"}` (2026-09-04), locking admins out of the dashboard and failing the Ansible health gate. Root cause: `adminApi.statusSummary` `collect()`ed every live `sessions` row for the PoP readiness tally, and prod crossed Convex's **32,000-document per-execution read limit**. Postgres (`pg_amcheck`) and every table were healthy; the coincident Ceph crash was unrelated. `REDACT_LOGS_TO_CLIENT` hides the real error even from `bunx convex run`; it only shows in `bunx convex logs`.

## Fix

- **Session counter.** New `stats:sessionCounts` `appState` row, bumped in every session write path (`sessions.ts` create/delete/delete-all/sweep + the lifecycle hard-delete cascade). `statusSummary` reads it in O(1). Rebuilt by `userStats.reconcileSessionCounts` from a new daily `session-counts-reconcile` cron and the deploy entrypoint.
- **One exact reconcile protocol for both counters** (`convex/lib/statusCounters.ts`), replacing the user counter's `live + (scanned − baseline)` delta write, which double-applied any change that landed before the scan reached its row (review P1; the user counter had the same flaw). `begin` pins the scan boundary at the newest visible `_creationTime` and opens a persisted run token; each page is read and its `scanPos` recorded in the same mutation; a change on a row the scan has already read (or will never read) is journaled, one it has yet to read is not; `finish` writes scanned + journal and refuses a superseded token or an incomplete scan. Shared-timestamp page boundaries are handled.
- **Fail-closed init** (review P2). The session row carries `initialized`; `statusSummary` exposes `pop.initialized` (additive, default true) and forces `readyToEnable=false` until the first reconcile completes; bumps on a missing row are no-ops. The dashboard shows an unknown state instead of 0/0.
- **Backend-server delete guard.** `deleteBackendServer` collected every subscription on the panel to check for live keys (would 500 on any real panel: sub docs carry `subCache`, so the 8 MiB limit bites first). Now one indexed `first()` per live state via a new `subscriptions.by_backend_server_state` index. The by-slug (Ansible) path had **no** guard and now shares it.
- **Dashboard** polls the status snapshot every 30 s.
- **Docs**: read-limit rule + traffic-scaled table list (`docs/project-inventory.md`), threat-model wording, cron list.

## Audit

All 62 `collect()` sites plus every `take`/`first`/`paginate` reviewed. Sweeps use `take`+drain-chain, admin lists paginate; no other unbounded read over a traffic-scaled table. Per-user delete cascades remain bounded by one account's rows (noted, not changed).

## Verification

- 1212 tests pass. New coverage: live counter through the real mutations; exact reconcile with a transition on each side of `scanPos`, a create mid-scan, a shared-timestamp page boundary, and a superseded run, for both counters; fail-closed init; delete guard on both paths. Typecheck + lint clean.
- Deploy is a single `up -d --build --force-recreate web deployer`: the schema push backfills the new index, then the entrypoint runs both reconciles. The existing prod `stats:userCounts` row is read as-is (flat storage kept; the new meta fields default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
